### PR TITLE
Docker-compose support for MongoDB with scripts update

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@ For build level release notes see https://github.com/mtconnect/cppagent/
   - 'mongodb' directory containing configuration files.
 ###Changed
 - Updated scripts to support docker-compose.
+- Updated README file. 
 
 ## [1.1.0.0] - 2024/04/05 - emprarthanak
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 For build level release notes see https://github.com/mtconnect/cppagent/
 
-## [Unreleased] 
+## [Unreleased]
+
+##[1.2.0.0] - 2024/04/29 - emAdithyaShenoy
+### Added
+- Jira Id: EP4US7
+  - MongoDB container included within docker-compose.
+  - 'mongodb' directory containing configuration files.
+###Changed
+- Updated scripts to support docker-compose.
 
 ## [1.1.0.0] - 2024/04/05 - emprarthanak
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Help syntax for the `ssUpgrade.sh`.
 
 ``` bash
 
-Syntax: ssUpgrade [-H|-a File_Name|-A|-d File_Name|-u Serial_number|-M|-O|-S|-h]
+Syntax: ssUpgrade [-H|-a File_Name|-A|-d File_Name|-u Serial_number|-M|-O|-S|-m|-h]
 
 options:
 
@@ -69,6 +69,8 @@ options:
 -O                Update the HEMsaw ODS application
 
 -S                Update the HEMsaw MongoDB application
+
+-m                Update the mongodb database to have default materials
 
 -h                Print this Help.
 

--- a/README.md
+++ b/README.md
@@ -1,58 +1,99 @@
 # MTConnect Smart Saw
 
 This is the release repo for all released devices and afg information to implement on the machine IPC.
+
 This is a Repo for the released MTConnect agent and device file for the SmartSaw platform
 
 ## Getting started
 
 To get the agent working on the IPC for the first time the github repoistory needs to be cloned. 
+
 ``` bash 
+
 git clone --recurse-submodules --progress --depth 1 https://github.com/HEM-Inc/MTConnect_SmartSaw.git mtconnect
-```
 
-After cloning the repository for the first time run the install script. This will locate the files into the correct locations and enable the systemctl service. Note if the agent is already created abd is an existing service then running this script can cause a lock file issue. 
+```
+After cloning the repository for the first time run the install script. This will locate the files into the correct locations.
+
 ``` bash
+
 sudo bash ssInstall.sh
-```
 
+```
 IF the agent has already be loaded then use the update script to update the files and restart the service. 
+
 ``` bash
+
 sudo bash ssUpgrade.sh
+
 ```
 
 Help syntax for the `ssInstall.sh`.
+
 ``` bash
-Syntax: ssInstall [-h|-a File_Name|-d File_Name|-c File_Name|-u Serial_number]
+
+Syntax: ssInstall [-h|-a File_Name|-d File_Name|-u Serial_number]
+
 options:
+
 -a File_Name        Declare the afg file name; Defaults to - SmartSaw_DC_HA.afg
+
 -d File_Name        Declare the MTConnect agent device file name; Defaults to - SmartSaw_DC_HA.xml
--c File_Name        Declare the config file name; Defaults to - mosquitto.conf
+
 -u Serial_number    Declare the serial number for the uuid; Defaults to - SmartSaw
+
 -h                  Print this Help.
+
 ```
 
 Help syntax for the `ssUpgrade.sh`.
+
 ``` bash
-Syntax: ssUpgrade [-H|-a File_Name|-A|-d File_Name|-u Serial_number|-M|-c File_Name|-h]
+
+Syntax: ssUpgrade [-H|-a File_Name|-A|-d File_Name|-u Serial_number|-M|-O|-S|-h]
+
 options:
+
 -H                Update the HEMsaw adapter application
+
 -a File_Name      Declare the afg file name; Defaults to - SmartSaw_DC_HA.afg
+
 -A                Update the MTConnect Agent application
+
 -d File_Name      Declare the MTConnect agent device file name; Defaults to - SmartSaw_DC_HA.xml
+
 -u Serial_number  Declare the serial number for the uuid; Defaults to - SmartSaw
+
 -M                Update the mosquitto broker application
--c File_Name      Declare the config file name; Defaults to - mosquitto.conf
+
+-O                Update the HEMsaw ODS application
+
+-S                Update the HEMsaw MongoDB application
+
 -h                Print this Help.
+
 ```
 
+Help syntax for the `ssClean.sh`.
 
-Help syntax for the `ssUninstall.sh`.
 ``` bash
-Syntax: ssUninstall.sh [-H|-A|-M|-D|-h]
+
+Syntax: ssUninstall.sh [-H|-A|-M|-O|-S|-D|-h]
+
 options:
+
 -H                Uninstall the HEMsaw adapter application
+
 -A                Uninstall the MTConnect Agent application
+
 -M                Uninstall the Mosquitto broker application
+
+-O                Uninstall the HEMsaw ODS application
+
+-S                Uninstall the HEMsaw MongoDB application
+
 -D                Uninstall Docker
+
 -h                Print this Help.
+
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,8 @@ services:
     hostname: ods
     image: hemsaw/ods:latest
     user: ods
+    ports:
+      - 9625:9625/tcp
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     volumes:
@@ -76,8 +78,28 @@ services:
         max-size: "10m"
         max-file: "3"
     working_dir: "/ods"
+    depends_on:
+    - mongodb
     restart: unless-stopped
-    network_mode: "host"
+
+  mongodb:
+    container_name: mongodb
+    hostname: mongodb
+    image: mongo:4.4
+    ports:
+      - 27017:27017/tcp
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+    volumes:
+      - "/etc/mongodb_data:/data/db"
+      - "/etc/mongodb/config/mongod.conf.orig:/etc/mongod.conf.orig"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: always
+
 
   watchtower:
     container_name: watchtower

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     volumes:
-      - "/etc/mongodb_data:/data/db"
+      - "/etc/mongodb/data/db:/data/db"
       - "/etc/mongodb/config/mongod.conf.orig:/etc/mongod.conf.orig"
     logging:
       driver: "json-file"
@@ -99,7 +99,6 @@ services:
         max-size: "10m"
         max-file: "3"
     restart: always
-
 
   watchtower:
     container_name: watchtower

--- a/docs/MongoDB_Dockerization_with_Docker-Compose.md
+++ b/docs/MongoDB_Dockerization_with_Docker-Compose.md
@@ -150,7 +150,7 @@ ssUpgrade script will be modified to include additional option '-S' for MongoDB 
 ssUpgrade command syntax will be as below after adding new option '-S'.
 
    ```
-   sudo bash ssUpgrade.sh [-H|-a File_Name|-A|-d File_Name|-u Serial_number|-M|-O|-S|-h]
+   sudo bash ssUpgrade.sh [-H|-a File_Name|-A|-d File_Name|-u Serial_number|-M|-O|-S|-m|-h]
    ```
    ``` 
       options:
@@ -161,7 +161,8 @@ ssUpgrade command syntax will be as below after adding new option '-S'.
       -u Serial_number  Declare the serial number for the uuid; Defaults to - SmartSaw
       -M                Update the mosquitto broker application
       -O                Update the HEMsaw ODS application
-      -S                Update the HEMsaw MongoDB application  
+      -S                Update the HEMsaw MongoDB application
+      -m                Update the MongoDB database with default materials
       -h                Print this Help.
    ```
 

--- a/docs/MongoDB_Dockerization_with_Docker-Compose.md
+++ b/docs/MongoDB_Dockerization_with_Docker-Compose.md
@@ -1,0 +1,300 @@
+# MongoDB Dockerization with Docker Compose 
+
+# Functional Specification Document
+#### Rev 0.1
+
+## Table of Contents
+* [List of Tables](#list-of-tables)
+* [Revision](#revision)
+* [Definition/Abbreviation](#definitionabbreviation)
+	* [Table 1: Abbreviations](#table-1-abbreviations)
+* [Feature Overview](#1-feature-overview)
+	* [Requirements](#11-requirements)
+		* [Functional Requirements](#111-functional-requirements)
+		* [Configuration and Management Requirements](#112-configuration-and-management-requirements)
+		* [Scalability Requirements](#113-scalability-requirements)
+		* [Restart Requirements](#114-restart-requirements)
+		* [Error Handling](#115-error-handling)
+* [Functionality](#2-functionality)
+	* [Functional Description](#21-functional-description)
+* [Design](#3-design)
+	* [Overview](#31-overview)
+	* [DB Changes](#32-db-changes)
+* [Flow Diagrams](#4-flow-diagrams)
+* [Serviceability and Debug](#5-serviceability-and-debug)
+* [Restart Support](#6-restart-support)
+* [Upgrade](#7-upgrade)
+* [Restrictions/Limitations](#8-restrictionslimitations)
+* [Test plan](#9-test-plan)
+	* [Test cases](#91-test-cases)
+	* [Integration test cases](#92-integration-test-cases)
+
+### List of Tables
+[Table 1: Abbreviations](#table-1-abbreviations)
+
+### Revision
+| Rev |     Date    |       Author                | Change Description                |
+|:---:|:-----------:|:-------------------------:|:-----------------------------------:|
+| 0.1 |  04/29/2024           |       Adithya     |    Initial version  |
+
+
+
+### Definition/Abbreviation
+#### Table 1: Abbreviations
+| 	**Term**			   |         **Meaning**                 |
+|--------------------------|-------------------------------------|
+| ODS                      | Object Database Server              |                      |
+| IPC | Industrial PC |
+|PLC|Programmable Logic Controller|
+|HMI|Human Machine Interface|
+|ssUpgrade| SmartSaw Upgrade|
+|ssInstall| SmartSaw Install|
+|ssClean| SmartSaw Clean|
+|ssStatus| SmartSaw Status|
+
+## **1. Feature Overview**
+
+Docker Compose is a tool for defining and running multi-container Docker applications. It allows you to use a YAML file to configure your application's services, networks, and volumes, and then run and manage them with a single command.
+
+SmartSaw MTConnect Agent, MTConnect-SmartAdapter ,MQTT broker, ODS and MongoDB can be run as Docker service.
+
+ssUpgrade script can be used to start MongoDB, ODS, MTConnect-SmartAdapter, Agent
+and MQTT broker. By this way, ssUpgrade can automate SmartSaw software docker services MongoDB, ODS, MTConnect-SmartAdapter, Agent and MQTT service bring up.
+
+HEMSaw MTConnect_SmartSaw repo maintains ssUpgrade and related Docker-Compose tools.  
+
+This feature introduces the ability to add dockerized MongoDB containers within the docker-compose.yml file. Additionally, scripts such as ssInstall.sh, ssUpgrade.sh, ssClean.sh, and ssStatus.sh will be updated to maintain the HEMSaw software. 
+
+### **1.1 Requirements**
+#### 1.1.1 Functional Requirements
+1. *Docker Compose*:
+   Docker compose utility shall be updated to include MongoDB service.
+2. *ssUpgrade*:
+   Script shall be updated to incorporate MongoDB configuration files.Additionally,script option -S shall be added to selectively update MongoDB component. 
+ 
+3. *ssInstall*:
+Script shall be updated to install MongoDB software.
+4. *ssCleanup*:
+Script shall be updated to uninstall MongoDB software.
+
+5. *ssStatus*:
+ Script shall be updated to display the status of docker compose for MongoDB.
+
+#### 1.1.2  Configuration and Management Requirements
+1. MongoDB Configuration files required for docker compose shall be newly created.
+2. ODS configuration file, odscfg.yml it is required to set 'mongodb_host' to 'mongodb' and 'mongodb_port' to '27017' for connecting to MongoDB.
+
+#### 1.1.3 Scalability Requirements
+Not applicable
+
+#### 1.1.4 Restart Requirements
+Any Modification in configuration files related to MongoDB, ODS, MTConnect-SmartAdapter, MQTT and MTConnect Agent shall come into effect only upon ssUpgrade with required restart option.
+Restart options for MongoDB shall be -S respectively.
+
+
+#### 1.1.5 Error Handling
+Not Applicable
+
+## **2. Functionality**
+### **2.1. Functional Description**
+ 
+Docker Compose Script orchestartes the docker start trigger for all user specified dockers.Watchtower is a tool for automatically updating docker containers with the latest available images. 
+
+ssUpgrade is a bash script designed for the HEMSaw software. It installs and manages Docker compose, updates key components such as  MTConnect Agent, MQTT Broker, MTConnect-SmartAdapter, ODS and MongoDB. Users can easily customize settings, and the script ensures smooth operation by verifying permissions and simplifies system maintenance.
+
+ssInstall is a bash script automating the task of installing the MTConnect-Agent, MTConnect-SmartAdapter, MQTT, ODS and MongoDB. 
+
+ssClean is a bash script which automates the task of uninstalling components such as MTConnect-Agent,  MTConnect-SmartAdapter, MQTT, ODS, MongoDB and cleans the locally stored docker images.
+
+ssStatus is a bash script which provides the status of the docker compose of the each component such as MTConnect Agent,MTConnect-SmartAdapter, MQTT, ODS and MongoDB.
+
+
+## **3. Design**
+### **3.1. Overview**
+### **3.1.1 Docker-Compose** :
+Following Docker-Compose.yml file attributes needs to be updated for MongoDB. 
+    
+ - container_name: This attribute sets the hostname for the container which will be 'mongodb' respectively.
+ - hostname: This abbtribute sets the hostname for the container. 'mongodb'
+ - image: mongo:4.4 image is pulled from the official MongoDB Docker Hub repository. 
+ - labels: Adds a label to enable automatic updates using Watchtower.
+ - volumes: Mounts the  directory on the host to the directory inside the container.Persistant Mongodb data is stored in etc/mongodb_data/
+ - logging: Configures logging for the container with a JSON file driver and limits log file size to 10 MB with a maximum of 3 log files.
+ - ports: This attribute will map port on the host to port/tcp inside the container for communication. Port number 27017 will be used for Mongodb.
+ - restart: Specifies the container to restart automatically unless explicitly stopped.
+
+ In the updated ODS compose attributes, the usage of 'network_mode':'host' has been removed, and instead, port mapping for '9625' is implemented to facilitate ODS connection Additionally, the 'depends_on' field has been included to specify the dependency on MongoDB.
+
+ Note: MongoDB image version 4.4 is chosen due to limitations with the IPC not supporting the CPU AVX instruction set which is a requirement for the MongoDB versions released after 5.0.
+    
+### **3.1.2 ssInstall script**
+ It is required to run ssInstall script for the first time while setting up SmartSaw software in IPC.
+
+ ssInstall will be modified to install Dockerized MongoDB.
+ This action will copy all the configuration files required for MongoDB into etc corresponding directories.
+
+   ```
+     sudo bash ssInstall.sh [-h|-a File_Name|-d File_Name|-u Serial_number]
+   ```
+   ``` 
+     options:
+     -a File_Name        Declare the afg file name; Defaults to - SmartSaw_DC_HA.afg
+     -d File_Name        Declare the MTConnect agent device file name; Defaults to - SmartSaw_DC_HA.xml
+     -u Serial_number    Declare the serial number for the uuid; Defaults to - SmartSaw
+     -h                  Print this Help.
+   ```
+
+### **3.1.3 ssUpgrade Script**
+ssUpgrade script will be modified to include additional option '-S' for MongoDB specific upgrade. When '-S' option is used, only MongoDB docker will be updated and other dockers will not be updated unless until specified.
+
+ssUpgrade command syntax will be as below after adding new option '-S'.
+
+   ```
+   sudo bash ssUpgrade.sh [-H|-a File_Name|-A|-d File_Name|-u Serial_number|-M|-O|-S|-h]
+   ```
+   ``` 
+      options:
+      -H                Update the HEMsaw Adapter application
+      -a File_Name      Declare the afg file name; Defaults to - SmartSaw_DC_HA.afg
+      -A                Update the MTConnect Agent application
+      -d File_Name      Declare the MTConnect agent device file name; Defaults to - SmartSaw_DC_HA.xml
+      -u Serial_number  Declare the serial number for the uuid; Defaults to - SmartSaw
+      -M                Update the mosquitto broker application
+      -O                Update the HEMsaw ODS application
+      -S                Update the HEMsaw MongoDB application  
+      -h                Print this Help.
+   ```
+
+### **3.1.4 ssClean Script**
+ssClean script will be modified to include addtional option '-S' for MongoDB specific clean. When '-S' option is used only MongoDB configurations within etc will be removed.  
+
+ssClean command syntax will be as below after adding new option '-S'.
+
+
+   ```
+    sudo bash ssClean.sh [-H|-A|-M|-O|-S|-D|-h]
+   ```
+   ```
+    options:
+    -H                Uninstall the HEMsaw adapter application
+    -A                Uninstall the MTConnect Agent application
+    -M                Uninstall the Mosquitto broker application
+    -O                Uninstall the HEMsaw ODS application
+    -S                Uninstall the HEMsaw MongoDB application 
+    -D                Uninstall Docker
+    -h                Print this Help.
+
+   ```
+ 
+
+### **3.1.5 ssStatus Script**
+- To display the status of the MTConnect Agent, MTConnect-SmartAdapter, MQTT broker,ODS and MongoDB inside Docker compose container.
+   ```
+   sudo bash ssStatus.sh
+   ```
+   
+### **3.1.6 Docker-Compose Logs**
+- Below command will be used to list the logs generated during docker compose activity.
+
+   ```
+   docker-compose logs [<container_name>]
+   ```
+
+### **3.1.7 MongoDB Configurations**
+MongoDB configurations such as mongod.conf.orig are being added to MTConnect-SmartSaw within mongodb/config directory inorder to run the Dockerised MongoDB container.
+
+### **3.1.8 Interaction with MongoDB**
+- Docker Command Line Access:
+   - below command will be used to access the MongoDB shell within the Docker container.
+
+     ```
+     docker exec -it mongodb bash 
+     ```
+- Direct MongoDB Shell Access:
+   - Once inside the Docker container, execute the **mongo** command to access the MongoDB command line interface.
+
+- Note: When adding data to MongoDB using scripts, ensure to use "mongodb" as the hostname instead of "localhost" to establish the connection with Dockerized MongoDB.
+### **3.2. DB Changes**
+No direct database changes are required, as MongoDB instances are deployed as containers and use persistent volumes for data storage.
+
+## **4. Flow Diagrams**
+Not Applicable
+
+## **5. Serviceability and Debug**
+Serviceability includes options for logging MongoDB containers using tools like Docker-compose logs.
+
+## **6. Restart Support**
+Changes to the configuration files related to Mongodb, ODS, MTConnect-SmartAdapter, MQTT broker, and MTConnect Agent will take effect exclusively through ssUpgrade along with the necessary restart option.
+
+The restart options for MongoDB will be -S, respectively.
+
+## **7. Upgrade**
+HEMSaw utilizes ssUpgrade script to restart MTConnect Agent, MTConnect-SmartAdapter, MQTT broker, ODS and MongoDB.
+## **8. Restrictions/Limitations**
+Not Applicable 
+
+## **9. Test plan**
+
+### **9.1 Test cases**
+| Test Case   ID |                        Test Case   Description                       |                     Expected Result                     | Status | Comments |
+|:--------------:|--------------------------------------------------------------------|-------------------------------------------------------|:------:|:--------:|
+| 1| Verify ssInstall script for installation of all components | Installs all the docker components|PASS | |
+| 2 | Verify ssInstall script with -a \<afg_file>  | Installs adapter component with specified afg file| PASS| |
+| 3 | Verify ssInstall script with -d \<device_file>| Installs Agent component with specified Device XML file| PASS| |
+| 4 | Verify ssInstall script with -u \<UUID> |Declares the specified serial number for uuid within Agent device xml file |PASS| |
+|5|  Verify ssInstall script with -h option  | Displays Help options|PASS | |
+| 6|Verify ssInstall script with invalid options |Displays the valid options for ssInstall |PASS | Negative testcase
+|        7       | Verify ssUpgrade script                                            |Successful execution of all docker components. |  PASS   |          |
+|        8       | Verify ssUpgrade script with -H option                                            | Docker compose runs with updated Adapter configuration files                    |  PASS      |          |
+|        9       | Verify ssUpgrade script without -H option when adapter configurations are modified | Docker compose runs with previous adapter configurations               |   PASS     |          |
+| 10|Verify ssUpgrade script with -H -a \<afg_file> option |Successful execution with the specified afg file for adapter |PASS  | |
+|       11     | Verify ssUpgrade script with -a \<afg_file>                                            |Docker compose runs with previous afg file for Adapter           |  PASS      |          |
+|        12       | Verify ssUpgrade script with -A option                                             | Successful execution with Agent updated files                      | PASS      |          |
+|        13       | Verify ssUpgrade script without -A option when agent configurations are modified   | Docker compose runs with previous agent configurations| PASS | |
+|14                 |Verify for the change in values of different data items in REST API        |Verified for functionalmode and saw_controller_mode dataItem.          |PASS||
+|       15      | Verify ssUpgrade script with -d \<device_file>                                             | Docker compose runs with previous device file for Agent             |  PASS      |          |
+|16|Verify ssUpgrade script with -A -d \<device_file>| Successful execution with specified device file for agent|PASS| |
+|       17       | Verify ssUpgrade script with -A -u \<UUID>                                             | Updates Agent device xml file with specified serial number           |  PASS      |          |
+|       18       | Verify ssUpgrade script with -u \<UUID>                                             | Agent device file will not be updated with specified serial number number           |  PASS     |          |
+|        19      | Verify ssUpgrade script with -O option                                            |Successful execution with ods updated files                  |  PASS      |          |
+|        20      | Verify ssUpgrade script without -O option when ODS configurations are modified     |Docker compose runs with previous ods configurations |PASS | |
+|        21     | Verify ssUpgrade script with -S option                                            |Successful execution with Mongodb updated files                  |PASS        |          |
+|        22      | Verify ssUpgrade script without -S option when Mongodb configurations are modified     |Docker compose runs with previous Mongodb configurations | PASS| |
+|        23      | Verify ssUpgrade script with -M option                                             |Successful execution with Mosqitto updated files                        |   PASS     |          |
+|        24      | Verify ssUpgrade script without -M option when mqtt configurations are modified    |Docker compose runs with previous mqtt configurations                  | PASS       |          |
+|       25     | Verify ssUpgrade script with -h option                                             | Displays Help options                                    |  PASS      |          |
+| 26|Verify ssUpgrade script with invalid options |Displays the valid options for ssUpgrade script |PASS  | Negative testcase|
+|       27       | Verify ssClean script with -H option                                              | Deletes adapter configurations from etc                                |   PASS     |          |
+|       28       | Verify ssClean script with -A option                                               | Deletes Agent configurations from etc                                  |  PASS      |          |
+|       29       | Verify ssClean script with -D option                                               | Shutting down all existing Docker containers                                       | PASS       |         |
+|       30       | Verify ssClean script with -O option                                               | Deletes ODS configurations from etc                                    |PASS        |          |
+|       31       | Verify ssClean script with -M option                                               | Deletes MQTT configurations from etc                                    |   PASS     |          |
+|       32       | Verify ssClean script with -S option                                               | Deletes Mongodb configurations from etc                                    | PASS       |          |
+| 33|Verify ssClean script with invalid options |Displays the valid options in ssClean |PASS|Negative testcase|
+|34|Verify data persists across MongoDB container restarts.| Ensure changes are retained after container restarts|PASS | |
+|       35       | Verify ssStatus script                                                      |  Provides the status of each container                     |  PASS      |          |
+|36|Verify Docker Compose logs for Mongodb|Displays Mongodb-specific logs |PASS | 
+|37|Verify Docker Compose logs for ODS|Displays ODS-specific logs based on provided severity in yml file|PASS | 
+|38|Verify Docker Compose logs for Adapter|Displays Adapter-specific logs based on provided severity in afg file|PASS |
+|39|Verify Docker Compose logs for MQTT broker|Displays MQTT broker-specific logs|PASS | |
+|40|Verify Docker Compose logs for Agent|Displays Agent-specific logs based on provided severity in cfg file|PASS |  
+
+### **9.2 Integration test cases**
+| Test Case ID |                  Test Case Description                 |                    Expected Result                    | Status | Comments |
+|:------------:|------------------------------------------------------|-----------------------------------------------------|:------:|:--------:|
+|1| verify ssUpgrade script with -u \<UUID> '-A'and '-H' options |Successful execution with changed UUID in agent device file and  latest adapter configuration file |PASS| |
+|2| verify ssUpgrade script with -d  \<device_file>  '-A'and '-S' options |Successful execution with changed device file for agent and  latest MongoDB configuration file |PASS  | |
+|3|Verify ssUpgrade script with '-H' -a \<afg_file> and '-A' options|Successful execution with specified afg file for adapter and updated configuration for agent.|PASS | |
+|4| verify ssUpgrade script with '-A' '-H' '-M' '-O' '-S' options |Successful execution with latest configuration files | PASS| | 
+|5|Verify Mongodb Connection with invalid Host name and IP Address in ODS configuration | unsuccessful connection between ODS and Mongodb|PASS | |  
+|6|Verify Adding Jobs in HMI|Successful appending jobs in MongoDB|PASS | |
+|7|Verify deleting Jobs in HMI| Successful deleting jobs in MongoDB|PASS | | 
+|       8     | Verify the connection between adapter and agent in IPC | Successful sending of data to agent                   |  PASS      |          |
+| 9 | Verify the connection between Agent and Mosquitto | Data sent from agent to MQTT on topic 'mtconnect/'|PASS | |
+|       10      | Verify the connection between PLC and ODS in IPC       | Successful connection between PLC and ODS             |  PASS     |          |
+|       11      | Verify the connection between ODS and MongoDB in IPC   | Successfully able to access job and material from HMI | PASS       |          |
+
+
+
+
+

--- a/mongodb/config/mongod.conf.orig
+++ b/mongodb/config/mongod.conf.orig
@@ -1,0 +1,28 @@
+ mongod.conf
+
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
+
+# Where and how to store data.
+storage:
+  dbPath: /var/lib/mongodb
+#  engine:
+#  wiredTiger:
+
+# where to write logging data.
+systemLog:
+  destination: file
+  logAppend: true
+  verbosity: 2
+  path: /var/log/mongodb/mongod.log
+
+# network interfaces
+net:
+  port: 27017
+  bindIp: 0.0.0.0
+
+
+# how the process runs
+processManagement:
+  timeZoneInfo: /usr/share/zoneinfo
+

--- a/mongodb/data/MaterialLibrary.csv
+++ b/mongodb/data/MaterialLibrary.csv
@@ -1,0 +1,1437 @@
+UUID,NAME,CLASS,SIZE,BLADE SPEED,CHIP REMOVAL RATE,FORCE
+,A36 Solid - 2 In,Carbon Steel,2,275,14,175
+,A36 Solid - 4 In,Carbon Steel,4,275,14,175
+,A36 Solid - 6 In,Carbon Steel,6,275,14,175
+,A36 Solid - 8 In,Carbon Steel,8,275,14,175
+,A36 Solid - 10 In,Carbon Steel,10,275,14,175
+,A36 Solid - 12 In,Carbon Steel,12,275,14,175
+,A36 Solid - 16 In,Carbon Steel,16,275,14,175
+,A36 Solid - 20 In,Carbon Steel,20,275,14,175
+,A36 Tubing - 2 In,Carbon Steel,2,275,14,175
+,A36 Tubing - 4 In,Carbon Steel,4,275,14,175
+,A36 Tubing - 6 In,Carbon Steel,6,275,14,175
+,A36 Tubing - 8 In,Carbon Steel,8,275,14,175
+,A36 Tubing - 10 In,Carbon Steel,10,275,14,175
+,A36 Tubing - 12 In,Carbon Steel,12,275,14,175
+,A36 Tubing - 16 In,Carbon Steel,16,275,14,175
+,A36 Tubing - 20 In,Carbon Steel,20,275,14,175
+,A48 CLASS 20 - 2 In,Carbon Steel,2,156,9.4,265
+,A48 CLASS 20 - 4 In,Carbon Steel,4,156,9.4,265
+,A48 CLASS 20 - 6 In,Carbon Steel,6,156,9.4,265
+,A48 CLASS 20 - 8 In,Carbon Steel,8,156,9.4,265
+,A48 CLASS 20 - 10 In,Carbon Steel,10,156,9.4,265
+,A48 CLASS 20 - 12 In,Carbon Steel,12,156,9.4,265
+,A48 CLASS 20 - 16 In,Carbon Steel,16,156,9.4,265
+,A48 CLASS 20 - 20 In,Carbon Steel,20,156,9.4,265
+,A536 Grade 60-40-18 - 2 In,Carbon Steel,2,156,9.4,265
+,A536 Grade 60-40-18 - 4 In,Carbon Steel,4,156,9.4,265
+,A536 Grade 60-40-18 - 6 In,Carbon Steel,6,156,9.4,265
+,A536 Grade 60-40-18 - 8 In,Carbon Steel,8,156,9.4,265
+,A536 Grade 60-40-18 - 10 In,Carbon Steel,10,156,9.4,265
+,A536 Grade 60-40-18 - 12 In,Carbon Steel,12,156,9.4,265
+,A536 Grade 60-40-18 - 16 In,Carbon Steel,16,156,9.4,265
+,A536 Grade 60-40-18 - 20 In,Carbon Steel,20,156,9.4,265
+,A536 Grade 120-90-02 - 2 In,Carbon Steel,2,156,9.4,265
+,A536 Grade 120-90-02 - 4 In,Carbon Steel,4,156,9.4,265
+,A536 Grade 120-90-02 - 6 In,Carbon Steel,6,156,9.4,265
+,A536 Grade 120-90-02 - 8 In,Carbon Steel,8,156,9.4,265
+,A536 Grade 120-90-02 - 10 In,Carbon Steel,10,156,9.4,265
+,A536 Grade 120-90-02 - 12 In,Carbon Steel,12,156,9.4,265
+,A536 Grade 120-90-02 - 16 In,Carbon Steel,16,156,9.4,265
+,A536 Grade 120-90-02 - 20 In,Carbon Steel,20,156,9.4,265
+,1145-12L15 Steel - 2 In,Carbon Steel,2,285,24,150
+,1145-12L15 Steel - 4 In,Carbon Steel,4,270,24,150
+,1145-12L15 Steel - 6 In,Carbon Steel,6,255,24,150
+,1145-12L15 Steel - 8 In,Carbon Steel,8,240,24,150
+,1145-12L15 Steel - 10 In,Carbon Steel,10,225,24,150
+,1145-12L15 Steel - 12 In,Carbon Steel,12,215,24,150
+,1145-12L15 Steel - 16 In,Carbon Steel,16,190,24,150
+,1145-12L15 Steel - 20 In,Carbon Steel,20,170,24,150
+,1524 Alloy - 2 In,Alloy Steel,2,180,14,210
+,1524 Alloy - 4 In,Alloy Steel,4,170,14,210
+,1524 Alloy - 6 In,Alloy Steel,6,160,14,210
+,1524 Alloy - 8 In,Alloy Steel,8,150,14,210
+,1524 Alloy - 10 In,Alloy Steel,10,145,14,210
+,1524 Alloy - 12 In,Alloy Steel,12,135,14,210
+,1524 Alloy - 16 In,Alloy Steel,16,120,14,210
+,1524 Alloy - 20 In,Alloy Steel,20,105,14,210
+,1541 Alloy - 2 In,Alloy Steel,2,215,14,210
+,1541 Alloy - 4 In,Alloy Steel,4,200,14,210
+,1541 Alloy - 6 In,Alloy Steel,6,190,14,210
+,1541 Alloy - 8 In,Alloy Steel,8,180,14,210
+,1541 Alloy - 10 In,Alloy Steel,10,170,14,210
+,1541 Alloy - 12 In,Alloy Steel,12,160,14,210
+,1541 Alloy - 16 In,Alloy Steel,16,140,14,210
+,1541 Alloy - 20 In,Alloy Steel,20,125,14,210
+,4140-4150 Alloy - 2 In,Alloy Steel,2,215,9.6,245
+,4140-4150 Alloy - 4 In,Alloy Steel,4,200,9.6,245
+,4140-4150 Alloy - 6 In,Alloy Steel,6,190,9.6,245
+,4140-4150 Alloy - 8 In,Alloy Steel,8,180,9.6,245
+,4140-4150 Alloy - 10 In,Alloy Steel,10,170,9.6,245
+,4140-4150 Alloy - 12 In,Alloy Steel,12,160,9.6,245
+,4140-4150 Alloy - 16 In,Alloy Steel,16,140,9.6,245
+,4140-4150 Alloy - 20 In,Alloy Steel,20,125,9.6,245
+,4340-5160-6150 Allow - 2 In,Alloy Steel,2,200,9.6,245
+,4340-5160-6150 Allow - 4 In,Alloy Steel,4,190,9.6,245
+,4340-5160-6150 Allow - 6 In,Alloy Steel,6,185,9.6,245
+,4340-5160-6150 Allow - 8 In,Alloy Steel,8,175,9.6,245
+,4340-5160-6150 Allow - 10 In,Alloy Steel,10,160,9.6,245
+,4340-5160-6150 Allow - 12 In,Alloy Steel,12,150,9.6,245
+,4340-5160-6150 Allow - 16 In,Alloy Steel,16,135,9.6,245
+,4340-5160-6150 Allow - 20 In,Alloy Steel,20,125,9.6,245
+,5210-9310 Alloy - 2 In,Alloy Steel,2,170,12.4,245
+,5210-9310 Alloy - 4 In,Alloy Steel,4,160,12.4,245
+,5210-9310 Alloy - 6 In,Alloy Steel,6,150,12.4,245
+,5210-9310 Alloy - 8 In,Alloy Steel,8,140,12.4,245
+,5210-9310 Alloy - 10 In,Alloy Steel,10,135,12.4,245
+,5210-9310 Alloy - 12 In,Alloy Steel,12,125,12.4,245
+,5210-9310 Alloy - 16 In,Alloy Steel,16,115,12.4,245
+,5210-9310 Alloy - 20 In,Alloy Steel,20,100,12.4,245
+,8620 Alloy - 2 In,Alloy Steel,2,230,9.6,210
+,8620 Alloy - 4 In,Alloy Steel,4,215,9.6,210
+,8620 Alloy - 6 In,Alloy Steel,6,205,9.6,210
+,8620 Alloy - 8 In,Alloy Steel,8,190,9.6,210
+,8620 Alloy - 10 In,Alloy Steel,10,180,9.6,210
+,8620 Alloy - 12 In,Alloy Steel,12,170,9.6,210
+,8620 Alloy - 16 In,Alloy Steel,16,150,9.6,210
+,8620 Alloy - 20 In,Alloy Steel,20,135,9.6,210
+,8640 Alloy - 2 In,Alloy Steel,2,195,9.6,210
+,8640 Alloy - 4 In,Alloy Steel,4,185,9.6,210
+,8640 Alloy - 6 In,Alloy Steel,6,175,9.6,210
+,8640 Alloy - 8 In,Alloy Steel,8,165,9.6,210
+,8640 Alloy - 10 In,Alloy Steel,10,155,9.6,210
+,8640 Alloy - 12 In,Alloy Steel,12,145,9.6,210
+,8640 Alloy - 16 In,Alloy Steel,16,130,9.6,210
+,8640 Alloy - 20 In,Alloy Steel,20,115,9.6,210
+,2024 Aluminum - 2 In,Aluminum,2,350,20,175
+,2024 Aluminum - 4 In,Aluminum,4,350,20,175
+,2024 Aluminum - 6 In,Aluminum,6,350,20,175
+,2024 Aluminum - 8 In,Aluminum,8,350,20,175
+,2024 Aluminum - 10 In,Aluminum,10,350,20,175
+,2024 Aluminum - 12 In,Aluminum,12,350,20,175
+,2024 Aluminum - 16 In,Aluminum,16,350,20,175
+,2024 Aluminum - 20 In,Aluminum,20,350,20,175
+,5052 Aluminum - 2 In,Aluminum,2,350,20,175
+,5052 Aluminum - 4 In,Aluminum,4,350,20,175
+,5052 Aluminum - 6 In,Aluminum,6,350,20,175
+,5052 Aluminum - 8 In,Aluminum,8,350,20,175
+,5052 Aluminum - 10 In,Aluminum,10,350,20,175
+,5052 Aluminum - 12 In,Aluminum,12,350,20,175
+,5052 Aluminum - 16 In,Aluminum,16,350,20,175
+,5052 Aluminum - 20 In,Aluminum,20,350,20,175
+,6061 Aluminum - 2 In,Aluminum,2,350,20,175
+,6061 Aluminum - 4 In,Aluminum,4,350,20,175
+,6061 Aluminum - 6 In,Aluminum,6,350,20,175
+,6061 Aluminum - 8 In,Aluminum,8,350,20,175
+,6061 Aluminum - 10 In,Aluminum,10,350,20,175
+,6061 Aluminum - 12 In,Aluminum,12,350,20,175
+,6061 Aluminum - 16 In,Aluminum,16,350,20,175
+,6061 Aluminum - 20 In,Aluminum,20,350,20,175
+,7075 Aluminum - 2 In,Aluminum,2,350,20,175
+,7075 Aluminum - 4 In,Aluminum,4,350,20,175
+,7075 Aluminum - 6 In,Aluminum,6,350,20,175
+,7075 Aluminum - 8 In,Aluminum,8,350,20,175
+,7075 Aluminum - 10 In,Aluminum,10,350,20,175
+,7075 Aluminum - 12 In,Aluminum,12,350,20,175
+,7075 Aluminum - 16 In,Aluminum,16,350,20,175
+,7075 Aluminum - 20 In,Aluminum,20,350,20,175
+,301-303 SS - 2 In,Stainless Steel,2,90,4.6,480
+,301-303 SS - 4 In,Stainless Steel,4,90,4.6,480
+,301-303 SS - 6 In,Stainless Steel,6,90,4.6,480
+,301-303 SS - 8 In,Stainless Steel,8,90,4.6,480
+,301-303 SS - 10 In,Stainless Steel,10,90,4.6,480
+,301-303 SS - 12 In,Stainless Steel,12,90,4.6,480
+,301-303 SS - 16 In,Stainless Steel,16,90,4.6,480
+,301-303 SS - 20 In,Stainless Steel,20,90,4.6,480
+,304-304L SS - 2 In,Stainless Steel,2,90,4.6,480
+,304-304L SS - 4 In,Stainless Steel,4,90,4.6,480
+,304-304L SS - 6 In,Stainless Steel,6,90,4.6,480
+,304-304L SS - 8 In,Stainless Steel,8,90,4.6,480
+,304-304L SS - 10 In,Stainless Steel,10,90,4.6,480
+,304-304L SS - 12 In,Stainless Steel,12,90,4.6,480
+,304-304L SS - 16 In,Stainless Steel,16,90,4.6,480
+,304-304L SS - 20 In,Stainless Steel,20,90,4.6,480
+,316-316L SS - 2 In,Stainless Steel,2,90,4.6,480
+,316-316L SS - 4 In,Stainless Steel,4,90,4.6,480
+,316-316L SS - 6 In,Stainless Steel,6,90,4.6,480
+,316-316L SS - 8 In,Stainless Steel,8,90,4.6,480
+,316-316L SS - 10 In,Stainless Steel,10,90,4.6,480
+,316-316L SS - 12 In,Stainless Steel,12,90,4.6,480
+,316-316L SS - 16 In,Stainless Steel,16,90,4.6,480
+,316-316L SS - 20 In,Stainless Steel,20,90,4.6,480
+,321 SS - 2 In,Stainless Steel,2,90,4.6,480
+,321 SS - 4 In,Stainless Steel,4,90,4.6,480
+,321 SS - 6 In,Stainless Steel,6,90,4.6,480
+,321 SS - 8 In,Stainless Steel,8,90,4.6,480
+,321 SS - 10 In,Stainless Steel,10,90,4.6,480
+,321 SS - 12 In,Stainless Steel,12,90,4.6,480
+,321 SS - 16 In,Stainless Steel,16,90,4.6,480
+,321 SS - 20 In,Stainless Steel,20,90,4.6,480
+,410-420 SS - 2 In,Stainless Steel,2,101,5.4,375
+,410-420 SS - 4 In,Stainless Steel,4,101,5.4,375
+,410-420 SS - 6 In,Stainless Steel,6,101,5.4,375
+,410-420 SS - 8 In,Stainless Steel,8,101,5.4,375
+,410-420 SS - 10 In,Stainless Steel,10,101,5.4,375
+,410-420 SS - 12 In,Stainless Steel,12,101,5.4,375
+,410-420 SS - 16 In,Stainless Steel,16,101,5.4,375
+,410-420 SS - 20 In,Stainless Steel,20,101,5.4,375
+,440 SS - 2 In,Stainless Steel,2,90,4.6,480
+,440 SS - 4 In,Stainless Steel,4,90,4.6,480
+,440 SS - 6 In,Stainless Steel,6,90,4.6,480
+,440 SS - 8 In,Stainless Steel,8,90,4.6,480
+,440 SS - 10 In,Stainless Steel,10,90,4.6,480
+,440 SS - 12 In,Stainless Steel,12,90,4.6,480
+,440 SS - 16 In,Stainless Steel,16,90,4.6,480
+,440 SS - 20 In,Stainless Steel,20,90,4.6,480
+,17-4 SS - 2 In,Stainless Steel,2,71,2.8,780
+,17-4 SS - 4 In,Stainless Steel,4,71,2.8,780
+,17-4 SS - 6 In,Stainless Steel,6,71,2.8,780
+,17-4 SS - 8 In,Stainless Steel,8,71,2.8,780
+,17-4 SS - 10 In,Stainless Steel,10,71,2.8,780
+,17-4 SS - 12 In,Stainless Steel,12,71,2.8,780
+,17-4 SS - 16 In,Stainless Steel,16,71,2.8,780
+,17-4 SS - 20 In,Stainless Steel,20,71,2.8,780
+,15-5 SS - 2 In,Stainless Steel,2,71,2.8,780
+,15-5 SS - 4 In,Stainless Steel,4,71,2.8,780
+,15-5 SS - 6 In,Stainless Steel,6,71,2.8,780
+,15-5 SS - 8 In,Stainless Steel,8,71,2.8,780
+,15-5 SS - 10 In,Stainless Steel,10,71,2.8,780
+,15-5 SS - 12 In,Stainless Steel,12,71,2.8,780
+,15-5 SS - 16 In,Stainless Steel,16,71,2.8,780
+,15-5 SS - 20 In,Stainless Steel,20,71,2.8,780
+,Super Alloy A286 2 In,Super Alloy,2,66,2.4,800
+,Super Alloy A286 4 In,Super Alloy,4,66,2.4,800
+,Super Alloy A286 6 In,Super Alloy,6,66,2.4,800
+,Super Alloy A286 8 In,Super Alloy,8,66,2.4,800
+,Super Alloy A286 10 In,Super Alloy,10,66,2.4,800
+,Super Alloy A286 12 In,Super Alloy,12,66,2.4,800
+,Super Alloy A286 16 In,Super Alloy,16,66,2.4,800
+,Super Alloy A286 20 In,Super Alloy,20,66,2.4,800
+,Monel K500 2 In,Super Alloy,2,71,2.8,750
+,Monel K500 4 In,Super Alloy,4,71,2.8,750
+,Monel K500 6 In,Super Alloy,6,71,2.8,750
+,Monel K500 8 In,Super Alloy,8,71,2.8,750
+,Monel K500 10 In,Super Alloy,10,71,2.8,750
+,Monel K500 12 In,Super Alloy,12,71,2.8,750
+,Monel K500 16 In,Super Alloy,16,71,2.8,750
+,Monel K500 20 In,Super Alloy,20,71,2.8,750
+,Incoloy 330 2 In,Super Alloy,2,71,2.8,750
+,Incoloy 330 4 In,Super Alloy,4,71,2.8,750
+,Incoloy 330 6 In,Super Alloy,6,71,2.8,750
+,Incoloy 330 8 In,Super Alloy,8,71,2.8,750
+,Incoloy 330 10 In,Super Alloy,10,71,2.8,750
+,Incoloy 330 12 In,Super Alloy,12,71,2.8,750
+,Incoloy 330 16 In,Super Alloy,16,71,2.8,750
+,Incoloy 330 20 In,Super Alloy,20,71,2.8,750
+,Inconel 600 2 In,Super Alloy,2,71,2.8,750
+,Inconel 600 4 In,Super Alloy,4,71,2.8,750
+,Inconel 600 6 In,Super Alloy,6,71,2.8,750
+,Inconel 600 8 In,Super Alloy,8,71,2.8,750
+,Inconel 600 10 In,Super Alloy,10,71,2.8,750
+,Inconel 600 12 In,Super Alloy,12,71,2.8,750
+,Inconel 600 16 In,Super Alloy,16,71,2.8,750
+,Inconel 600 20 In,Super Alloy,20,71,2.8,750
+,Nitronic 60 2 In,Super Alloy,2,90,4.6,460
+,Nitronic 60 4 In,Super Alloy,4,90,4.6,460
+,Nitronic 60 6 In,Super Alloy,6,90,4.6,460
+,Nitronic 60 8 In,Super Alloy,8,90,4.6,460
+,Nitronic 60 10 In,Super Alloy,10,90,4.6,460
+,Nitronic 60 12 In,Super Alloy,12,90,4.6,460
+,Nitronic 60 16 In,Super Alloy,16,90,4.6,460
+,Nitronic 60 20 In,Super Alloy,20,90,4.6,460
+,RENE 88 2 In,Super Alloy,2,71,2.8,750
+,RENE 88 4 In,Super Alloy,4,71,2.8,750
+,RENE 88 6 In,Super Alloy,6,71,2.8,750
+,RENE 88 8 In,Super Alloy,8,71,2.8,750
+,RENE 88 10 In,Super Alloy,10,71,2.8,750
+,RENE 88 12 In,Super Alloy,12,71,2.8,750
+,RENE 88 16 In,Super Alloy,16,71,2.8,750
+,RENE 88 20 In,Super Alloy,20,71,2.8,750
+,Waspalloy 2 In,Super Alloy,2,71,2.8,750
+,Waspalloy 4 In,Super Alloy,4,71,2.8,750
+,Waspalloy 6 In,Super Alloy,6,71,2.8,750
+,Waspalloy 8 In,Super Alloy,8,71,2.8,750
+,Waspalloy 10 In,Super Alloy,10,71,2.8,750
+,Waspalloy 12 In,Super Alloy,12,71,2.8,750
+,Waspalloy 16 In,Super Alloy,16,71,2.8,750
+,Waspalloy 20 In,Super Alloy,20,71,2.8,750
+,Hastelloy 2 In,Super Alloy,2,66,2.4,800
+,Hastelloy 4 In,Super Alloy,4,66,2.4,800
+,Hastelloy 6 In,Super Alloy,6,66,2.4,800
+,Hastelloy 8 In,Super Alloy,8,66,2.4,800
+,Hastelloy 10 In,Super Alloy,10,66,2.4,800
+,Hastelloy 12 In,Super Alloy,12,66,2.4,800
+,Hastelloy 16 In,Super Alloy,16,66,2.4,800
+,Hastelloy 20 In,Super Alloy,20,66,2.4,800
+,Incoloy 825 2 In,Super Alloy,2,71,2.8,750
+,Incoloy 825 4 In,Super Alloy,4,71,2.8,750
+,Incoloy 825 6 In,Super Alloy,6,71,2.8,750
+,Incoloy 825 8 In,Super Alloy,8,71,2.8,750
+,Incoloy 825 10 In,Super Alloy,10,71,2.8,750
+,Incoloy 825 12 In,Super Alloy,12,71,2.8,750
+,Incoloy 825 16 In,Super Alloy,16,71,2.8,750
+,Incoloy 825 20 In,Super Alloy,20,71,2.8,750
+,Inconel 625 2 In,Super Alloy,2,66,2.4,800
+,Inconel 625 4 In,Super Alloy,4,66,2.4,800
+,Inconel 625 6 In,Super Alloy,6,66,2.4,800
+,Inconel 625 8 In,Super Alloy,8,66,2.4,800
+,Inconel 625 10 In,Super Alloy,10,66,2.4,800
+,Inconel 625 12 In,Super Alloy,12,66,2.4,800
+,Inconel 625 16 In,Super Alloy,16,66,2.4,800
+,Inconel 625 20 In,Super Alloy,20,66,2.4,800
+,Inconel 718 2 In,Super Alloy,2,71,2.8,750
+,Inconel 718 4 In,Super Alloy,4,71,2.8,750
+,Inconel 718 6 In,Super Alloy,6,71,2.8,750
+,Inconel 718 8 In,Super Alloy,8,71,2.8,750
+,Inconel 718 10 In,Super Alloy,10,71,2.8,750
+,Inconel 718 12 In,Super Alloy,12,71,2.8,750
+,Inconel 718 16 In,Super Alloy,16,71,2.8,750
+,Inconel 718 20 In,Super Alloy,20,71,2.8,750
+,Nitronic 90 2 In,Super Alloy,2,66,2.4,800
+,Nitronic 90 4 In,Super Alloy,4,66,2.4,800
+,Nitronic 90 6 In,Super Alloy,6,66,2.4,800
+,Nitronic 90 8 In,Super Alloy,8,66,2.4,800
+,Nitronic 90 10 In,Super Alloy,10,66,2.4,800
+,Nitronic 90 12 In,Super Alloy,12,66,2.4,800
+,Nitronic 90 16 In,Super Alloy,16,66,2.4,800
+,Nitronic 90 20 In,Super Alloy,20,66,2.4,800
+,Ni-Span 2 In,Titanium,2,66,2.4,800
+,Ni-Span 4 In,Titanium,4,66,2.4,800
+,Ni-Span 6 In,Titanium,6,66,2.4,800
+,Ni-Span 8 In,Titanium,8,66,2.4,800
+,Ni-Span 10 In,Titanium,10,66,2.4,800
+,Ni-Span 12 In,Titanium,12,66,2.4,800
+,Ni-Span 16 In,Titanium,16,66,2.4,800
+,Ni-Span 20 In,Titanium,20,66,2.4,800
+,Titanium 99% CP Ti 2 In,Titanium,2,81,3.8,550
+,Titanium 99% CP Ti 4 In,Titanium,4,81,3.8,550
+,Titanium 99% CP Ti 6 In,Titanium,6,81,3.8,550
+,Titanium 99% CP Ti 8 In,Titanium,8,81,3.8,550
+,Titanium 99% CP Ti 10 In,Titanium,10,81,3.8,550
+,Titanium 99% CP Ti 12 In,Titanium,12,81,3.8,550
+,Titanium 99% CP Ti 16 In,Titanium,16,81,3.8,550
+,Titanium 99% CP Ti 20 In,Titanium,20,81,3.8,550
+,Titanium Ti-6Al-4V 2 In,Titanium,2,81,3.8,550
+,Titanium Ti-6Al-4V 4 In,Titanium,4,81,3.8,550
+,Titanium Ti-6Al-4V 6 In,Titanium,6,81,3.8,550
+,Titanium Ti-6Al-4V 8 In,Titanium,8,81,3.8,550
+,Titanium Ti-6Al-4V 10 In,Titanium,10,81,3.8,550
+,Titanium Ti-6Al-4V 12 In,Titanium,12,81,3.8,550
+,Titanium Ti-6Al-4V 16 In,Titanium,16,81,3.8,550
+,Titanium Ti-6Al-4V 20 In,Titanium,20,81,3.8,550
+,CDA 715 (Copper Nickel) 2 In,Copper Brass Bronze,2,156,9.4,390
+,CDA 715 (Copper Nickel) 4 In,Copper Brass Bronze,4,156,9.4,390
+,CDA 715 (Copper Nickel) 6 In,Copper Brass Bronze,6,156,9.4,390
+,CDA 715 (Copper Nickel) 8 In,Copper Brass Bronze,8,156,9.4,390
+,CDA 715 (Copper Nickel) 10 In,Copper Brass Bronze,10,156,9.4,390
+,CDA 715 (Copper Nickel) 12 In,Copper Brass Bronze,12,156,9.4,390
+,CDA 715 (Copper Nickel) 16 In,Copper Brass Bronze,16,156,9.4,390
+,CDA 715 (Copper Nickel) 20 In,Copper Brass Bronze,20,156,9.4,390
+,CDA 464 (Naval Brass) 2 In,Copper Brass Bronze,2,156,9.4,390
+,CDA 464 (Naval Brass) 4 In,Copper Brass Bronze,4,156,9.4,390
+,CDA 464 (Naval Brass) 6 In,Copper Brass Bronze,6,156,9.4,390
+,CDA 464 (Naval Brass) 8 In,Copper Brass Bronze,8,156,9.4,390
+,CDA 464 (Naval Brass) 10 In,Copper Brass Bronze,10,156,9.4,390
+,CDA 464 (Naval Brass) 12 In,Copper Brass Bronze,12,156,9.4,390
+,CDA 464 (Naval Brass) 16 In,Copper Brass Bronze,16,156,9.4,390
+,CDA 464 (Naval Brass) 20 In,Copper Brass Bronze,20,156,9.4,390
+,CDA 230 (Red Brass) 2 In,Copper Brass Bronze,2,198,12.8,300
+,CDA 230 (Red Brass) 4 In,Copper Brass Bronze,4,198,12.8,300
+,CDA 230 (Red Brass) 6 In,Copper Brass Bronze,6,198,12.8,300
+,CDA 230 (Red Brass) 8 In,Copper Brass Bronze,8,198,12.8,300
+,CDA 230 (Red Brass) 10 In,Copper Brass Bronze,10,198,12.8,300
+,CDA 230 (Red Brass) 12 In,Copper Brass Bronze,12,198,12.8,300
+,CDA 230 (Red Brass) 16 In,Copper Brass Bronze,16,198,12.8,300
+,CDA 230 (Red Brass) 20 In,Copper Brass Bronze,20,198,12.8,300
+,CDA 260 (Cartridge Brass) 2 In,Copper Brass Bronze,2,198,12.8,300
+,CDA 260 (Cartridge Brass) 4 In,Copper Brass Bronze,4,198,12.8,300
+,CDA 260 (Cartridge Brass) 6 In,Copper Brass Bronze,6,198,12.8,300
+,CDA 260 (Cartridge Brass) 8 In,Copper Brass Bronze,8,198,12.8,300
+,CDA 260 (Cartridge Brass) 10 In,Copper Brass Bronze,10,198,12.8,300
+,CDA 260 (Cartridge Brass) 12 In,Copper Brass Bronze,12,198,12.8,300
+,CDA 260 (Cartridge Brass) 16 In,Copper Brass Bronze,16,198,12.8,300
+,CDA 260 (Cartridge Brass) 20 In,Copper Brass Bronze,20,198,12.8,300
+,CDA 865 (Aluminum Bronze) 2 In,Copper Brass Bronze,2,101,5.4,680
+,CDA 865 (Aluminum Bronze) 4 In,Copper Brass Bronze,4,101,5.4,680
+,CDA 865 (Aluminum Bronze) 6 In,Copper Brass Bronze,6,101,5.4,680
+,CDA 865 (Aluminum Bronze) 8 In,Copper Brass Bronze,8,101,5.4,680
+,CDA 865 (Aluminum Bronze) 10 In,Copper Brass Bronze,10,101,5.4,680
+,CDA 865 (Aluminum Bronze) 12 In,Copper Brass Bronze,12,101,5.4,680
+,CDA 865 (Aluminum Bronze) 16 In,Copper Brass Bronze,16,101,5.4,680
+,CDA 865 (Aluminum Bronze) 20 In,Copper Brass Bronze,20,101,5.4,680
+,CDA 863 (Manganese Bronze) 2 In,Copper Brass Bronze,2,101,5.4,680
+,CDA 863 (Manganese Bronze) 4 In,Copper Brass Bronze,4,101,5.4,680
+,CDA 863 (Manganese Bronze) 6 In,Copper Brass Bronze,6,101,5.4,680
+,CDA 863 (Manganese Bronze) 8 In,Copper Brass Bronze,8,101,5.4,680
+,CDA 863 (Manganese Bronze) 10 In,Copper Brass Bronze,10,101,5.4,680
+,CDA 863 (Manganese Bronze) 12 In,Copper Brass Bronze,12,101,5.4,680
+,CDA 863 (Manganese Bronze) 16 In,Copper Brass Bronze,16,101,5.4,680
+,CDA 863 (Manganese Bronze) 20 In,Copper Brass Bronze,20,101,5.4,680
+,AMPCO 18 2 In,Copper Brass Bronze,2,198,12.8,480
+,AMPCO 18 4 In,Copper Brass Bronze,4,198,12.8,480
+,AMPCO 18 6 In,Copper Brass Bronze,6,198,12.8,480
+,AMPCO 18 8 In,Copper Brass Bronze,8,198,12.8,480
+,AMPCO 18 10 In,Copper Brass Bronze,10,198,12.8,480
+,AMPCO 18 12 In,Copper Brass Bronze,12,198,12.8,480
+,AMPCO 18 16 In,Copper Brass Bronze,16,198,12.8,480
+,AMPCO 18 20 In,Copper Brass Bronze,20,198,12.8,480
+,AMPCO 21 2 In,Copper Brass Bronze,2,156,9.4,730
+,AMPCO 21 4 In,Copper Brass Bronze,4,156,9.4,730
+,AMPCO 21 6 In,Copper Brass Bronze,6,156,9.4,730
+,AMPCO 21 8 In,Copper Brass Bronze,8,156,9.4,730
+,AMPCO 21 10 In,Copper Brass Bronze,10,156,9.4,730
+,AMPCO 21 12 In,Copper Brass Bronze,12,156,9.4,730
+,AMPCO 21 16 In,Copper Brass Bronze,16,156,9.4,730
+,AMPCO 21 20 In,Copper Brass Bronze,20,156,9.4,730
+,AMPCO 25 2 In,Copper Brass Bronze,2,156,9.4,730
+,AMPCO 25 4 In,Copper Brass Bronze,4,156,9.4,730
+,AMPCO 25 6 In,Copper Brass Bronze,6,156,9.4,730
+,AMPCO 25 8 In,Copper Brass Bronze,8,156,9.4,730
+,AMPCO 25 10 In,Copper Brass Bronze,10,156,9.4,730
+,AMPCO 25 12 In,Copper Brass Bronze,12,156,9.4,730
+,AMPCO 25 16 In,Copper Brass Bronze,16,156,9.4,730
+,AMPCO 25 20 In,Copper Brass Bronze,20,156,9.4,730
+,CDA 20 (Commerial Bronze) 2 In,Copper Brass Bronze,2,198,12.8,480
+,CDA 20 (Commerial Bronze) 4 In,Copper Brass Bronze,4,198,12.8,480
+,CDA 20 (Commerial Bronze) 6 In,Copper Brass Bronze,6,198,12.8,480
+,CDA 20 (Commerial Bronze) 8 In,Copper Brass Bronze,8,198,12.8,480
+,CDA 20 (Commerial Bronze) 10 In,Copper Brass Bronze,10,198,12.8,480
+,CDA 20 (Commerial Bronze) 12 In,Copper Brass Bronze,12,198,12.8,480
+,CDA 20 (Commerial Bronze) 16 In,Copper Brass Bronze,16,198,12.8,480
+,CDA 20 (Commerial Bronze) 20 In,Copper Brass Bronze,20,198,12.8,480
+,CDA 932 (Pb Tin Bronze) 2 In,Copper Brass Bronze,2,198,12.8,480
+,CDA 932 (Pb Tin Bronze) 4 In,Copper Brass Bronze,4,198,12.8,480
+,CDA 932 (Pb Tin Bronze) 6 In,Copper Brass Bronze,6,198,12.8,480
+,CDA 932 (Pb Tin Bronze) 8 In,Copper Brass Bronze,8,198,12.8,480
+,CDA 932 (Pb Tin Bronze) 10 In,Copper Brass Bronze,10,198,12.8,480
+,CDA 932 (Pb Tin Bronze) 12 In,Copper Brass Bronze,12,198,12.8,480
+,CDA 932 (Pb Tin Bronze) 16 In,Copper Brass Bronze,16,198,12.8,480
+,CDA 932 (Pb Tin Bronze) 20 In,Copper Brass Bronze,20,198,12.8,480
+,L6 - 2 In,Tool Steel,2,90,4.6,700
+,L6 - 4 In,Tool Steel,4,90,4.6,700
+,L6 - 6 In,Tool Steel,6,90,4.6,700
+,L6 - 8 In,Tool Steel,8,90,4.6,700
+,L6 - 10 In,Tool Steel,10,90,4.6,700
+,L6 - 12 In,Tool Steel,12,90,4.6,700
+,L6 - 16 In,Tool Steel,16,90,4.6,700
+,L6 - 20 In,Tool Steel,20,90,4.6,700
+,W1 - 2 In,Tool Steel,2,101,5.4,550
+,W1 - 4 In,Tool Steel,4,101,5.4,550
+,W1 - 6 In,Tool Steel,6,101,5.4,550
+,W1 - 8 In,Tool Steel,8,101,5.4,550
+,W1 - 10 In,Tool Steel,10,101,5.4,550
+,W1 - 12 In,Tool Steel,12,101,5.4,550
+,W1 - 16 In,Tool Steel,16,101,5.4,550
+,W1 - 20 In,Tool Steel,20,101,5.4,550
+,D2 - 2 In,Tool Steel,2,75,3,700
+,D2 - 4 In,Tool Steel,4,75,3,700
+,D2 - 6 In,Tool Steel,6,75,3,700
+,D2 - 8 In,Tool Steel,8,75,3,700
+,D2 - 10 In,Tool Steel,10,75,3,700
+,D2 - 12 In,Tool Steel,12,75,3,700
+,D2 - 16 In,Tool Steel,16,75,3,700
+,D2 - 20 In,Tool Steel,20,75,3,700
+,A2 - 2 In,Tool Steel,2,101,5.4,700
+,A2 - 4 In,Tool Steel,4,101,5.4,700
+,A2 - 6 In,Tool Steel,6,101,5.4,700
+,A2 - 8 In,Tool Steel,8,101,5.4,700
+,A2 - 10 In,Tool Steel,10,101,5.4,700
+,A2 - 12 In,Tool Steel,12,101,5.4,700
+,A2 - 16 In,Tool Steel,16,101,5.4,700
+,A2 - 20 In,Tool Steel,20,101,5.4,700
+,A6 - 2 In,Tool Steel,2,101,5.4,700
+,A6 - 4 In,Tool Steel,4,101,5.4,700
+,A6 - 6 In,Tool Steel,6,101,5.4,700
+,A6 - 8 In,Tool Steel,8,101,5.4,700
+,A6 - 10 In,Tool Steel,10,101,5.4,700
+,A6 - 12 In,Tool Steel,12,101,5.4,700
+,A6 - 16 In,Tool Steel,16,101,5.4,700
+,A6 - 20 In,Tool Steel,20,101,5.4,700
+,A10 - 2 In,Tool Steel,2,101,5.4,700
+,A10 - 4 In,Tool Steel,4,101,5.4,700
+,A10 - 6 In,Tool Steel,6,101,5.4,700
+,A10 - 8 In,Tool Steel,8,101,5.4,700
+,A10 - 10 In,Tool Steel,10,101,5.4,700
+,A10 - 12 In,Tool Steel,12,101,5.4,700
+,A10 - 16 In,Tool Steel,16,101,5.4,700
+,A10 - 20 In,Tool Steel,20,101,5.4,700
+,H13 - 2 In,Tool Steel,2,101,5.4,700
+,H13 - 4 In,Tool Steel,4,101,5.4,700
+,H13 - 6 In,Tool Steel,6,101,5.4,700
+,H13 - 8 In,Tool Steel,8,101,5.4,700
+,H13 - 10 In,Tool Steel,10,101,5.4,700
+,H13 - 12 In,Tool Steel,12,101,5.4,700
+,H13 - 16 In,Tool Steel,16,101,5.4,700
+,H13 - 20 In,Tool Steel,20,101,5.4,700
+,H25 - 2 In,Tool Steel,2,81,3.8,825
+,H25 - 4 In,Tool Steel,4,81,3.8,825
+,H25 - 6 In,Tool Steel,6,81,3.8,825
+,H25 - 8 In,Tool Steel,8,81,3.8,825
+,H25 - 10 In,Tool Steel,10,81,3.8,825
+,H25 - 12 In,Tool Steel,12,81,3.8,825
+,H25 - 16 In,Tool Steel,16,81,3.8,825
+,H25 - 20 In,Tool Steel,20,81,3.8,825
+,O1 - 2 In,Tool Steel,2,101,5.4,700
+,O1 - 4 In,Tool Steel,4,101,5.4,700
+,O1 - 6 In,Tool Steel,6,101,5.4,700
+,O1 - 8 In,Tool Steel,8,101,5.4,700
+,O1 - 10 In,Tool Steel,10,101,5.4,700
+,O1 - 12 In,Tool Steel,12,101,5.4,700
+,O1 - 16 In,Tool Steel,16,101,5.4,700
+,O1 - 20 In,Tool Steel,20,101,5.4,700
+,O2 - 2 In,Tool Steel,2,101,5.4,700
+,O2 - 4 In,Tool Steel,4,101,5.4,700
+,O2 - 6 In,Tool Steel,6,101,5.4,700
+,O2 - 8 In,Tool Steel,8,101,5.4,700
+,O2 - 10 In,Tool Steel,10,101,5.4,700
+,O2 - 12 In,Tool Steel,12,101,5.4,700
+,O2 - 16 In,Tool Steel,16,101,5.4,700
+,O2 - 20 In,Tool Steel,20,101,5.4,700
+,M2 - 2 In,Tool Steel,2,81,3.8,825
+,M2 - 4 In,Tool Steel,4,81,3.8,825
+,M2 - 6 In,Tool Steel,6,81,3.8,825
+,M2 - 8 In,Tool Steel,8,81,3.8,825
+,M2 - 10 In,Tool Steel,10,81,3.8,825
+,M2 - 12 In,Tool Steel,12,81,3.8,825
+,M2 - 16 In,Tool Steel,16,81,3.8,825
+,M2 - 20 In,Tool Steel,20,81,3.8,825
+,M4 - 2 In,Tool Steel,2,81,3.8,825
+,M4 - 4 In,Tool Steel,4,81,3.8,825
+,M4 - 6 In,Tool Steel,6,81,3.8,825
+,M4 - 8 In,Tool Steel,8,81,3.8,825
+,M4 - 10 In,Tool Steel,10,81,3.8,825
+,M4 - 12 In,Tool Steel,12,81,3.8,825
+,M4 - 16 In,Tool Steel,16,81,3.8,825
+,M4 - 20 In,Tool Steel,20,81,3.8,825
+,M10 - 2 In,Tool Steel,2,81,3.8,825
+,M10 - 4 In,Tool Steel,4,81,3.8,825
+,M10 - 6 In,Tool Steel,6,81,3.8,825
+,M10 - 8 In,Tool Steel,8,81,3.8,825
+,M10 - 10 In,Tool Steel,10,81,3.8,825
+,M10 - 12 In,Tool Steel,12,81,3.8,825
+,M10 - 16 In,Tool Steel,16,81,3.8,825
+,M10 - 20 In,Tool Steel,20,81,3.8,825
+,M42 - 2 In,Tool Steel,2,81,3.8,825
+,M42 - 4 In,Tool Steel,4,81,3.8,825
+,M42 - 6 In,Tool Steel,6,81,3.8,825
+,M42 - 8 In,Tool Steel,8,81,3.8,825
+,M42 - 10 In,Tool Steel,10,81,3.8,825
+,M42 - 12 In,Tool Steel,12,81,3.8,825
+,M42 - 16 In,Tool Steel,16,81,3.8,825
+,M42 - 20 In,Tool Steel,20,81,3.8,825
+,T1 - 2 In,Tool Steel,2,71,2.8,880
+,T1 - 4 In,Tool Steel,4,71,2.8,880
+,T1 - 6 In,Tool Steel,6,71,2.8,880
+,T1 - 8 In,Tool Steel,8,71,2.8,880
+,T1 - 10 In,Tool Steel,10,71,2.8,880
+,T1 - 12 In,Tool Steel,12,71,2.8,880
+,T1 - 16 In,Tool Steel,16,71,2.8,880
+,T1 - 20 In,Tool Steel,20,71,2.8,880
+,T15 - 2 In,Tool Steel,2,71,2.8,880
+,T15 - 4 In,Tool Steel,4,71,2.8,880
+,T15 - 6 In,Tool Steel,6,71,2.8,880
+,T15 - 8 In,Tool Steel,8,71,2.8,880
+,T15 - 10 In,Tool Steel,10,71,2.8,880
+,T15 - 12 In,Tool Steel,12,71,2.8,880
+,T15 - 16 In,Tool Steel,16,71,2.8,880
+,T15 - 20 In,Tool Steel,20,71,2.8,880
+,P3 - 2 In,Tool Steel,2,101,5.4,675
+,P3 - 4 In,Tool Steel,4,101,5.4,675
+,P3 - 6 In,Tool Steel,6,101,5.4,675
+,P3 - 8 In,Tool Steel,8,101,5.4,675
+,P3 - 10 In,Tool Steel,10,101,5.4,675
+,P3 - 12 In,Tool Steel,12,101,5.4,675
+,P3 - 16 In,Tool Steel,16,101,5.4,675
+,P3 - 20 In,Tool Steel,20,101,5.4,675
+,P20 - 2 In,Tool Steel,2,101,5.4,675
+,P20 - 4 In,Tool Steel,4,101,5.4,675
+,P20 - 6 In,Tool Steel,6,101,5.4,675
+,P20 - 8 In,Tool Steel,8,101,5.4,675
+,P20 - 10 In,Tool Steel,10,101,5.4,675
+,P20 - 12 In,Tool Steel,12,101,5.4,675
+,P20 - 16 In,Tool Steel,16,101,5.4,675
+,P20 - 20 In,Tool Steel,20,101,5.4,675
+,S1 - 2 In,Tool Steel,2,81,3.8,750
+,S1 - 4 In,Tool Steel,4,81,3.8,750
+,S1 - 6 In,Tool Steel,6,81,3.8,750
+,S1 - 8 In,Tool Steel,8,81,3.8,750
+,S1 - 10 In,Tool Steel,10,81,3.8,750
+,S1 - 12 In,Tool Steel,12,81,3.8,750
+,S1 - 16 In,Tool Steel,16,81,3.8,750
+,S1 - 20 In,Tool Steel,20,81,3.8,750
+,S5 - 2 In,Tool Steel,2,81,3.8,750
+,S5 - 4 In,Tool Steel,4,81,3.8,750
+,S5 - 6 In,Tool Steel,6,81,3.8,750
+,S5 - 8 In,Tool Steel,8,81,3.8,750
+,S5 - 10 In,Tool Steel,10,81,3.8,750
+,S5 - 12 In,Tool Steel,12,81,3.8,750
+,S5 - 16 In,Tool Steel,16,81,3.8,750
+,S5 - 20 In,Tool Steel,20,81,3.8,750
+,S7 - 2 In,Tool Steel,2,81,3.8,750
+,S7 - 4 In,Tool Steel,4,81,3.8,750
+,S7 - 6 In,Tool Steel,6,81,3.8,750
+,S7 - 8 In,Tool Steel,8,81,3.8,750
+,S7 - 10 In,Tool Steel,10,81,3.8,750
+,S7 - 12 In,Tool Steel,12,81,3.8,750
+,S7 - 16 In,Tool Steel,16,81,3.8,750
+,S7 - 20 In,Tool Steel,20,81,3.8,750
+,418 SS - 1 In,Stainless Steel,1,150,5,500
+,418 SS - 2 In,Stainless Steel,2,150,5,500
+,418 SS - 3 In,Stainless Steel,3,150,5,500
+,418 SS - 4 In,Stainless Steel,4,150,5,500
+,418 SS - 5 In,Stainless Steel,5,150,5,500
+,418 SS - 6 In,Stainless Steel,6,150,5,500
+,418 SS - 7 In,Stainless Steel,7,150,3,500
+,418 SS - 8 In,Stainless Steel,8,150,3,500
+,418 SS - 9 In,Stainless Steel,9,150,3,500
+,418 SS - 10 In,Stainless Steel,10,130,3,500
+,418 SS - 11 In,Stainless Steel,11,130,3,500
+,418 SS - 12 In,Stainless Steel,12,130,3,500
+,418 SS - 13 In,Stainless Steel,13,130,3,500
+,418 SS - 14 In,Stainless Steel,14,120,3,500
+,418 SS - 15 In,Stainless Steel,15,120,3,500
+,418 SS - 16 In,Stainless Steel,16,120,3,500
+,418 SS - 17 In,Stainless Steel,17,120,3,500
+,418 SS - 18 In,Stainless Steel,18,120,3,500
+,418 SS - 19 In,Stainless Steel,19,110,3,500
+,418 SS - 20 In,Stainless Steel,20,110,3,500
+,Alloy 13-8 - 1 In,Alloy Steel,1,120,3.5,500
+,Alloy 13-8 - 2 In,Alloy Steel,2,120,3.5,500
+,Alloy 13-8 - 3 In,Alloy Steel,3,110,3.5,500
+,Alloy 13-8 - 4 In,Alloy Steel,4,110,3.5,500
+,Alloy 13-8 - 5 In,Alloy Steel,5,110,3.5,500
+,Alloy 13-8 - 6 In,Alloy Steel,6,110,3.5,500
+,Alloy 13-8 - 7 In,Alloy Steel,7,110,3.5,500
+,Alloy 13-8 - 8 In,Alloy Steel,8,110,3.5,500
+,Alloy 13-8 - 9 In,Alloy Steel,9,110,3.5,500
+,Alloy 13-8 - 10 In,Alloy Steel,10,110,3,500
+,Alloy 13-8 - 11 In,Alloy Steel,11,110,3,500
+,Alloy 13-8 - 12 In,Alloy Steel,12,110,3,500
+,Alloy 13-8 - 13 In,Alloy Steel,13,110,3,500
+,Alloy 13-8 - 14 In,Alloy Steel,14,110,3,500
+,Alloy 13-8 - 15 In,Alloy Steel,15,110,3,500
+,Alloy 13-8 - 16 In,Alloy Steel,16,110,3,500
+,Alloy 13-8 - 17 In,Alloy Steel,17,110,3,500
+,Alloy 13-8 - 18 In,Alloy Steel,18,110,3,500
+,Alloy 13-8 - 19 In,Alloy Steel,19,100,2.5,500
+,Alloy 13-8 - 20 In,Alloy Steel,20,100,2.5,500
+,Alloy 15-7 - 1 In,Alloy Steel,1,120,3.5,500
+,Alloy 15-7 - 2 In,Alloy Steel,2,120,3.5,500
+,Alloy 15-7 - 3 In,Alloy Steel,3,110,3.5,500
+,Alloy 15-7 - 4 In,Alloy Steel,4,110,3.5,500
+,Alloy 15-7 - 5 In,Alloy Steel,5,110,3.5,500
+,Alloy 15-7 - 6 In,Alloy Steel,6,110,3.5,500
+,Alloy 15-7 - 7 In,Alloy Steel,7,110,3.5,500
+,Alloy 15-7 - 8 In,Alloy Steel,8,110,3.5,500
+,Alloy 15-7 - 9 In,Alloy Steel,9,110,3.5,500
+,Alloy 15-7 - 10 In,Alloy Steel,10,110,3,500
+,Alloy 15-7 - 11 In,Alloy Steel,11,110,3,500
+,Alloy 15-7 - 12 In,Alloy Steel,12,110,3,500
+,Alloy 15-7 - 13 In,Alloy Steel,13,110,3,500
+,Alloy 15-7 - 14 In,Alloy Steel,14,110,3,500
+,Alloy 15-7 - 15 In,Alloy Steel,15,110,3,500
+,Alloy 15-7 - 16 In,Alloy Steel,16,110,3,500
+,Alloy 15-7 - 17 In,Alloy Steel,17,110,3,500
+,Alloy 15-7 - 18 In,Alloy Steel,18,110,3,500
+,Alloy 15-7 - 19 In,Alloy Steel,19,100,2.5,500
+,Alloy 15-7 - 20 In,Alloy Steel,20,100,2.5,500
+,Alloy 188 - 1 In,Alloy Steel,1,100,3,500
+,Alloy 188 - 2 In,Alloy Steel,2,100,3,500
+,Alloy 188 - 3 In,Alloy Steel,3,90,3,500
+,Alloy 188 - 4 In,Alloy Steel,4,90,3,500
+,Alloy 188 - 5 In,Alloy Steel,5,90,3,500
+,Alloy 188 - 6 In,Alloy Steel,6,90,3,500
+,Alloy 188 - 7 In,Alloy Steel,7,80,2,500
+,Alloy 188 - 8 In,Alloy Steel,8,80,2,500
+,Alloy 188 - 9 In,Alloy Steel,9,80,2,500
+,Alloy 188 - 10 In,Alloy Steel,10,80,2,500
+,Alloy 188 - 11 In,Alloy Steel,11,80,2,500
+,Alloy 188 - 12 In,Alloy Steel,12,80,2,500
+,Alloy 188 - 13 In,Alloy Steel,13,80,2,500
+,Alloy 188 - 14 In,Alloy Steel,14,80,2,500
+,Alloy 188 - 15 In,Alloy Steel,15,80,2,500
+,Alloy 188 - 16 In,Alloy Steel,16,80,2,500
+,Alloy 188 - 17 In,Alloy Steel,17,80,2,500
+,Alloy 188 - 18 In,Alloy Steel,18,80,2,500
+,Alloy 188 - 19 In,Alloy Steel,19,80,2,500
+,Alloy 188 - 20 In,Alloy Steel,20,80,2,500
+,Alloy 20 - 1 In,Alloy Steel,1,100,3,500
+,Alloy 20 - 2 In,Alloy Steel,2,100,3,500
+,Alloy 20 - 3 In,Alloy Steel,3,90,3,500
+,Alloy 20 - 4 In,Alloy Steel,4,90,3,500
+,Alloy 20 - 5 In,Alloy Steel,5,90,3,500
+,Alloy 20 - 6 In,Alloy Steel,6,90,3,500
+,Alloy 20 - 7 In,Alloy Steel,7,80,2,500
+,Alloy 20 - 8 In,Alloy Steel,8,80,2,500
+,Alloy 20 - 9 In,Alloy Steel,9,80,2,500
+,Alloy 20 - 10 In,Alloy Steel,10,80,2,500
+,Alloy 20 - 11 In,Alloy Steel,11,80,2,500
+,Alloy 20 - 12 In,Alloy Steel,12,80,2,500
+,Alloy 20 - 13 In,Alloy Steel,13,80,2,500
+,Alloy 20 - 14 In,Alloy Steel,14,80,2,500
+,Alloy 20 - 15 In,Alloy Steel,15,80,2,500
+,Alloy 20 - 16 In,Alloy Steel,16,80,2,500
+,Alloy 20 - 17 In,Alloy Steel,17,80,2,500
+,Alloy 20 - 18 In,Alloy Steel,18,80,2,500
+,Alloy 20 - 19 In,Alloy Steel,19,80,2,500
+,Alloy 20 - 20 In,Alloy Steel,20,80,2,500
+,Alloy 21-6-9 - 1 In,Alloy Steel,1,100,3,500
+,Alloy 21-6-9 - 2 In,Alloy Steel,2,100,3,500
+,Alloy 21-6-9 - 3 In,Alloy Steel,3,90,3,500
+,Alloy 21-6-9 - 4 In,Alloy Steel,4,90,3,500
+,Alloy 21-6-9 - 5 In,Alloy Steel,5,90,3,500
+,Alloy 21-6-9 - 6 In,Alloy Steel,6,90,3,500
+,Alloy 21-6-9 - 7 In,Alloy Steel,7,80,2,500
+,Alloy 21-6-9 - 8 In,Alloy Steel,8,80,2,500
+,Alloy 21-6-9 - 9 In,Alloy Steel,9,80,2,500
+,Alloy 21-6-9 - 10 In,Alloy Steel,10,80,2,500
+,Alloy 21-6-9 - 11 In,Alloy Steel,11,80,2,500
+,Alloy 21-6-9 - 12 In,Alloy Steel,12,80,2,500
+,Alloy 21-6-9 - 13 In,Alloy Steel,13,80,2,500
+,Alloy 21-6-9 - 14 In,Alloy Steel,14,80,2,500
+,Alloy 21-6-9 - 15 In,Alloy Steel,15,80,2,500
+,Alloy 21-6-9 - 16 In,Alloy Steel,16,80,2,500
+,Alloy 21-6-9 - 17 In,Alloy Steel,17,80,2,500
+,Alloy 21-6-9 - 18 In,Alloy Steel,18,80,2,500
+,Alloy 21-6-9 - 19 In,Alloy Steel,19,80,2,500
+,Alloy 21-6-9 - 20 In,Alloy Steel,20,80,2,500
+,Alloy 230 - 1 In,Alloy Steel,1,100,3,500
+,Alloy 230 - 2 In,Alloy Steel,2,100,3,500
+,Alloy 230 - 3 In,Alloy Steel,3,90,3,500
+,Alloy 230 - 4 In,Alloy Steel,4,90,3,500
+,Alloy 230 - 5 In,Alloy Steel,5,90,3,500
+,Alloy 230 - 6 In,Alloy Steel,6,90,3,500
+,Alloy 230 - 7 In,Alloy Steel,7,80,2,500
+,Alloy 230 - 8 In,Alloy Steel,8,80,2,500
+,Alloy 230 - 9 In,Alloy Steel,9,80,2,500
+,Alloy 230 - 10 In,Alloy Steel,10,80,2,500
+,Alloy 230 - 11 In,Alloy Steel,11,80,2,500
+,Alloy 230 - 12 In,Alloy Steel,12,80,2,500
+,Alloy 230 - 13 In,Alloy Steel,13,80,2,500
+,Alloy 230 - 14 In,Alloy Steel,14,80,2,500
+,Alloy 230 - 15 In,Alloy Steel,15,80,2,500
+,Alloy 230 - 16 In,Alloy Steel,16,80,2,500
+,Alloy 230 - 17 In,Alloy Steel,17,80,2,500
+,Alloy 230 - 18 In,Alloy Steel,18,80,2,500
+,Alloy 230 - 19 In,Alloy Steel,19,80,2,500
+,Alloy 230 - 20 In,Alloy Steel,20,80,2,500
+,Alloy 263 - 1 In,Alloy Steel,1,100,3,500
+,Alloy 263 - 2 In,Alloy Steel,2,100,3,500
+,Alloy 263 - 3 In,Alloy Steel,3,90,3,500
+,Alloy 263 - 4 In,Alloy Steel,4,90,3,500
+,Alloy 263 - 5 In,Alloy Steel,5,90,3,500
+,Alloy 263 - 6 In,Alloy Steel,6,90,3,500
+,Alloy 263 - 7 In,Alloy Steel,7,80,2,500
+,Alloy 263 - 8 In,Alloy Steel,8,80,2,500
+,Alloy 263 - 9 In,Alloy Steel,9,80,2,500
+,Alloy 263 - 10 In,Alloy Steel,10,80,2,500
+,Alloy 263 - 11 In,Alloy Steel,11,80,2,500
+,Alloy 263 - 12 In,Alloy Steel,12,80,2,500
+,Alloy 263 - 13 In,Alloy Steel,13,80,2,500
+,Alloy 263 - 14 In,Alloy Steel,14,80,2,500
+,Alloy 263 - 15 In,Alloy Steel,15,80,2,500
+,Alloy 263 - 16 In,Alloy Steel,16,80,2,500
+,Alloy 263 - 17 In,Alloy Steel,17,80,2,500
+,Alloy 263 - 18 In,Alloy Steel,18,80,2,500
+,Alloy 263 - 19 In,Alloy Steel,19,80,2,500
+,Alloy 263 - 20 In,Alloy Steel,20,80,2,500
+,Alloy 330 - 1 In,Alloy Steel,1,100,3,500
+,Alloy 330 - 2 In,Alloy Steel,2,100,3,500
+,Alloy 330 - 3 In,Alloy Steel,3,90,3,500
+,Alloy 330 - 4 In,Alloy Steel,4,90,3,500
+,Alloy 330 - 5 In,Alloy Steel,5,90,3,500
+,Alloy 330 - 6 In,Alloy Steel,6,90,3,500
+,Alloy 330 - 7 In,Alloy Steel,7,80,2,500
+,Alloy 330 - 8 In,Alloy Steel,8,80,2,500
+,Alloy 330 - 9 In,Alloy Steel,9,80,2,500
+,Alloy 330 - 10 In,Alloy Steel,10,80,2,500
+,Alloy 330 - 11 In,Alloy Steel,11,80,2,500
+,Alloy 330 - 12 In,Alloy Steel,12,80,2,500
+,Alloy 330 - 13 In,Alloy Steel,13,80,2,500
+,Alloy 330 - 14 In,Alloy Steel,14,80,2,500
+,Alloy 330 - 15 In,Alloy Steel,15,80,2,500
+,Alloy 330 - 16 In,Alloy Steel,16,80,2,500
+,Alloy 330 - 17 In,Alloy Steel,17,80,2,500
+,Alloy 330 - 18 In,Alloy Steel,18,80,2,500
+,Alloy 330 - 19 In,Alloy Steel,19,80,2,500
+,Alloy 330 - 20 In,Alloy Steel,20,80,2,500
+,Alloy 60 - 1 In,Alloy Steel,1,100,3,500
+,Alloy 60 - 2 In,Alloy Steel,2,100,3,500
+,Alloy 60 - 3 In,Alloy Steel,3,90,3,500
+,Alloy 60 - 4 In,Alloy Steel,4,90,3,500
+,Alloy 60 - 5 In,Alloy Steel,5,90,3,500
+,Alloy 60 - 6 In,Alloy Steel,6,90,3,500
+,Alloy 60 - 7 In,Alloy Steel,7,80,2,500
+,Alloy 60 - 8 In,Alloy Steel,8,80,2,500
+,Alloy 60 - 9 In,Alloy Steel,9,80,2,500
+,Alloy 60 - 10 In,Alloy Steel,10,80,2,500
+,Alloy 60 - 11 In,Alloy Steel,11,80,2,500
+,Alloy 60 - 12 In,Alloy Steel,12,80,2,500
+,Alloy 60 - 13 In,Alloy Steel,13,80,2,500
+,Alloy 60 - 14 In,Alloy Steel,14,80,2,500
+,Alloy 60 - 15 In,Alloy Steel,15,80,2,500
+,Alloy 60 - 16 In,Alloy Steel,16,80,2,500
+,Alloy 60 - 17 In,Alloy Steel,17,80,2,500
+,Alloy 60 - 18 In,Alloy Steel,18,80,2,500
+,Alloy 60 - 19 In,Alloy Steel,19,80,2,500
+,Alloy 60 - 20 In,Alloy Steel,20,80,2,500
+,Alloy 600 - 1 In,Alloy Steel,1,120,3.5,500
+,Alloy 600 - 2 In,Alloy Steel,2,120,3.5,500
+,Alloy 600 - 3 In,Alloy Steel,3,110,3.5,500
+,Alloy 600 - 4 In,Alloy Steel,4,110,3.5,500
+,Alloy 600 - 5 In,Alloy Steel,5,110,3.5,500
+,Alloy 600 - 6 In,Alloy Steel,6,110,3.5,500
+,Alloy 600 - 7 In,Alloy Steel,7,110,3.5,500
+,Alloy 600 - 8 In,Alloy Steel,8,110,3.5,500
+,Alloy 600 - 9 In,Alloy Steel,9,110,3.5,500
+,Alloy 600 - 10 In,Alloy Steel,10,110,3,500
+,Alloy 600 - 11 In,Alloy Steel,11,110,3,500
+,Alloy 600 - 12 In,Alloy Steel,12,110,3,500
+,Alloy 600 - 13 In,Alloy Steel,13,110,3,500
+,Alloy 600 - 14 In,Alloy Steel,14,110,3,500
+,Alloy 600 - 15 In,Alloy Steel,15,110,3,500
+,Alloy 600 - 16 In,Alloy Steel,16,110,3,500
+,Alloy 600 - 17 In,Alloy Steel,17,110,3,500
+,Alloy 600 - 18 In,Alloy Steel,18,110,3,500
+,Alloy 600 - 19 In,Alloy Steel,19,100,2.5,500
+,Alloy 600 - 20 In,Alloy Steel,20,100,2.5,500
+,Alloy 601 - 1 In,Alloy Steel,1,120,3.5,500
+,Alloy 601 - 2 In,Alloy Steel,2,120,3.5,500
+,Alloy 601 - 3 In,Alloy Steel,3,110,3.5,500
+,Alloy 601 - 4 In,Alloy Steel,4,110,3.5,500
+,Alloy 601 - 5 In,Alloy Steel,5,110,3.5,500
+,Alloy 601 - 6 In,Alloy Steel,6,110,3.5,500
+,Alloy 601 - 7 In,Alloy Steel,7,110,3.5,500
+,Alloy 601 - 8 In,Alloy Steel,8,110,3.5,500
+,Alloy 601 - 9 In,Alloy Steel,9,110,3.5,500
+,Alloy 601 - 10 In,Alloy Steel,10,110,3,500
+,Alloy 601 - 11 In,Alloy Steel,11,110,3,500
+,Alloy 601 - 12 In,Alloy Steel,12,110,3,500
+,Alloy 601 - 13 In,Alloy Steel,13,110,3,500
+,Alloy 601 - 14 In,Alloy Steel,14,110,3,500
+,Alloy 601 - 15 In,Alloy Steel,15,110,3,500
+,Alloy 601 - 16 In,Alloy Steel,16,110,3,500
+,Alloy 601 - 17 In,Alloy Steel,17,110,3,500
+,Alloy 601 - 18 In,Alloy Steel,18,110,3,500
+,Alloy 601 - 19 In,Alloy Steel,19,100,2.5,500
+,Alloy 601 - 20 In,Alloy Steel,20,100,2.5,500
+,Alloy 617 - 1 In,Alloy Steel,1,120,3.5,500
+,Alloy 617 - 2 In,Alloy Steel,2,120,3.5,500
+,Alloy 617 - 3 In,Alloy Steel,3,110,3.5,500
+,Alloy 617 - 4 In,Alloy Steel,4,110,3.5,500
+,Alloy 617 - 5 In,Alloy Steel,5,110,3.5,500
+,Alloy 617 - 6 In,Alloy Steel,6,110,3.5,500
+,Alloy 617 - 7 In,Alloy Steel,7,110,3.5,500
+,Alloy 617 - 8 In,Alloy Steel,8,110,3.5,500
+,Alloy 617 - 9 In,Alloy Steel,9,110,3.5,500
+,Alloy 617 - 10 In,Alloy Steel,10,110,3,500
+,Alloy 617 - 11 In,Alloy Steel,11,110,3,500
+,Alloy 617 - 12 In,Alloy Steel,12,110,3,500
+,Alloy 617 - 13 In,Alloy Steel,13,110,3,500
+,Alloy 617 - 14 In,Alloy Steel,14,110,3,500
+,Alloy 617 - 15 In,Alloy Steel,15,110,3,500
+,Alloy 617 - 16 In,Alloy Steel,16,110,3,500
+,Alloy 617 - 17 In,Alloy Steel,17,110,3,500
+,Alloy 617 - 18 In,Alloy Steel,18,110,3,500
+,Alloy 617 - 19 In,Alloy Steel,19,100,2.5,500
+,Alloy 617 - 20 In,Alloy Steel,20,100,2.5,500
+,Alloy 625 - 1 In,Alloy Steel,1,120,3.5,500
+,Alloy 625 - 2 In,Alloy Steel,2,120,3.5,500
+,Alloy 625 - 3 In,Alloy Steel,3,110,3.5,500
+,Alloy 625 - 4 In,Alloy Steel,4,110,3.5,500
+,Alloy 625 - 5 In,Alloy Steel,5,110,3.5,500
+,Alloy 625 - 6 In,Alloy Steel,6,110,3.5,500
+,Alloy 625 - 7 In,Alloy Steel,7,110,3.5,500
+,Alloy 625 - 8 In,Alloy Steel,8,110,3.5,500
+,Alloy 625 - 9 In,Alloy Steel,9,110,3.5,500
+,Alloy 625 - 10 In,Alloy Steel,10,110,3,500
+,Alloy 625 - 11 In,Alloy Steel,11,110,3,500
+,Alloy 625 - 12 In,Alloy Steel,12,110,3,500
+,Alloy 625 - 13 In,Alloy Steel,13,110,3,500
+,Alloy 625 - 14 In,Alloy Steel,14,110,3,500
+,Alloy 625 - 15 In,Alloy Steel,15,110,3,500
+,Alloy 625 - 16 In,Alloy Steel,16,110,3,500
+,Alloy 625 - 17 In,Alloy Steel,17,110,3,500
+,Alloy 625 - 18 In,Alloy Steel,18,110,3,500
+,Alloy 625 - 19 In,Alloy Steel,19,100,2.5,500
+,Alloy 625 - 20 In,Alloy Steel,20,100,2.5,500
+,Alloy 6B - 1 In,Alloy Steel,1,120,3.5,500
+,Alloy 6B - 2 In,Alloy Steel,2,120,3.5,500
+,Alloy 6B - 3 In,Alloy Steel,3,110,3.5,500
+,Alloy 6B - 4 In,Alloy Steel,4,110,3.5,500
+,Alloy 6B - 5 In,Alloy Steel,5,110,3.5,500
+,Alloy 6B - 6 In,Alloy Steel,6,110,3.5,500
+,Alloy 6B - 7 In,Alloy Steel,7,110,3.5,500
+,Alloy 6B - 8 In,Alloy Steel,8,110,3.5,500
+,Alloy 6B - 9 In,Alloy Steel,9,110,3.5,500
+,Alloy 6B - 10 In,Alloy Steel,10,110,3,500
+,Alloy 6B - 11 In,Alloy Steel,11,110,3,500
+,Alloy 6B - 12 In,Alloy Steel,12,110,3,500
+,Alloy 6B - 13 In,Alloy Steel,13,110,3,500
+,Alloy 6B - 14 In,Alloy Steel,14,110,3,500
+,Alloy 6B - 15 In,Alloy Steel,15,110,3,500
+,Alloy 6B - 16 In,Alloy Steel,16,110,3,500
+,Alloy 6B - 17 In,Alloy Steel,17,110,3,500
+,Alloy 6B - 18 In,Alloy Steel,18,110,3,500
+,Alloy 6B - 19 In,Alloy Steel,19,100,2.5,500
+,Alloy 6B - 20 In,Alloy Steel,20,100,2.5,500
+,Alloy 718 - 1 In,Alloy Steel,1,120,3.5,500
+,Alloy 718 - 2 In,Alloy Steel,2,120,3.5,500
+,Alloy 718 - 3 In,Alloy Steel,3,110,3.5,500
+,Alloy 718 - 4 In,Alloy Steel,4,110,3.5,500
+,Alloy 718 - 5 In,Alloy Steel,5,110,3.5,500
+,Alloy 718 - 6 In,Alloy Steel,6,110,3.5,500
+,Alloy 718 - 7 In,Alloy Steel,7,110,3.5,500
+,Alloy 718 - 8 In,Alloy Steel,8,110,3.5,500
+,Alloy 718 - 9 In,Alloy Steel,9,110,3.5,500
+,Alloy 718 - 10 In,Alloy Steel,10,110,3,500
+,Alloy 718 - 11 In,Alloy Steel,11,110,3,500
+,Alloy 718 - 12 In,Alloy Steel,12,110,3,500
+,Alloy 718 - 13 In,Alloy Steel,13,110,3,500
+,Alloy 718 - 14 In,Alloy Steel,14,110,3,500
+,Alloy 718 - 15 In,Alloy Steel,15,110,3,500
+,Alloy 718 - 16 In,Alloy Steel,16,110,3,500
+,Alloy 718 - 17 In,Alloy Steel,17,110,3,500
+,Alloy 718 - 18 In,Alloy Steel,18,110,3,500
+,Alloy 718 - 19 In,Alloy Steel,19,100,2.5,500
+,Alloy 718 - 20 In,Alloy Steel,20,100,2.5,500
+,Alloy 722 - 1 In,Alloy Steel,1,110,4,500
+,Alloy 722 - 2 In,Alloy Steel,2,110,4,500
+,Alloy 722 - 3 In,Alloy Steel,3,105,4,500
+,Alloy 722 - 4 In,Alloy Steel,4,105,4,500
+,Alloy 722 - 5 In,Alloy Steel,5,105,4,500
+,Alloy 722 - 6 In,Alloy Steel,6,105,4,500
+,Alloy 722 - 7 In,Alloy Steel,7,105,4,500
+,Alloy 722 - 8 In,Alloy Steel,8,105,4,500
+,Alloy 722 - 9 In,Alloy Steel,9,105,4,500
+,Alloy 722 - 10 In,Alloy Steel,10,105,3.5,500
+,Alloy 722 - 11 In,Alloy Steel,11,105,3.5,500
+,Alloy 722 - 12 In,Alloy Steel,12,105,3.5,500
+,Alloy 722 - 13 In,Alloy Steel,13,105,3.5,500
+,Alloy 722 - 14 In,Alloy Steel,14,100,3.5,500
+,Alloy 722 - 15 In,Alloy Steel,15,100,3.5,500
+,Alloy 722 - 16 In,Alloy Steel,16,100,3.5,500
+,Alloy 722 - 17 In,Alloy Steel,17,100,3.5,500
+,Alloy 722 - 18 In,Alloy Steel,18,100,3,500
+,Alloy 722 - 19 In,Alloy Steel,19,100,3,500
+,Alloy 722 - 20 In,Alloy Steel,20,100,3,500
+,Alloy 800 - 1 In,Alloy Steel,1,110,4,500
+,Alloy 800 - 2 In,Alloy Steel,2,110,4,500
+,Alloy 800 - 3 In,Alloy Steel,3,105,4,500
+,Alloy 800 - 4 In,Alloy Steel,4,105,4,500
+,Alloy 800 - 5 In,Alloy Steel,5,105,4,500
+,Alloy 800 - 6 In,Alloy Steel,6,105,4,500
+,Alloy 800 - 7 In,Alloy Steel,7,105,4,500
+,Alloy 800 - 8 In,Alloy Steel,8,105,4,500
+,Alloy 800 - 9 In,Alloy Steel,9,105,4,500
+,Alloy 800 - 10 In,Alloy Steel,10,105,3.5,500
+,Alloy 800 - 11 In,Alloy Steel,11,105,3.5,500
+,Alloy 800 - 12 In,Alloy Steel,12,105,3.5,500
+,Alloy 800 - 13 In,Alloy Steel,13,105,3.5,500
+,Alloy 800 - 14 In,Alloy Steel,14,100,3.5,500
+,Alloy 800 - 15 In,Alloy Steel,15,100,3.5,500
+,Alloy 800 - 16 In,Alloy Steel,16,100,3.5,500
+,Alloy 800 - 17 In,Alloy Steel,17,100,3.5,500
+,Alloy 800 - 18 In,Alloy Steel,18,100,3,500
+,Alloy 800 - 19 In,Alloy Steel,19,100,3,500
+,Alloy 800 - 20 In,Alloy Steel,20,100,3,500
+,Alloy 825 - 1 In,Alloy Steel,1,110,4,500
+,Alloy 825 - 2 In,Alloy Steel,2,110,4,500
+,Alloy 825 - 3 In,Alloy Steel,3,105,4,500
+,Alloy 825 - 4 In,Alloy Steel,4,105,4,500
+,Alloy 825 - 5 In,Alloy Steel,5,105,4,500
+,Alloy 825 - 6 In,Alloy Steel,6,105,4,500
+,Alloy 825 - 7 In,Alloy Steel,7,105,4,500
+,Alloy 825 - 8 In,Alloy Steel,8,105,4,500
+,Alloy 825 - 9 In,Alloy Steel,9,105,4,500
+,Alloy 825 - 10 In,Alloy Steel,10,105,3.5,500
+,Alloy 825 - 11 In,Alloy Steel,11,105,3.5,500
+,Alloy 825 - 12 In,Alloy Steel,12,105,3.5,500
+,Alloy 825 - 13 In,Alloy Steel,13,105,3.5,500
+,Alloy 825 - 14 In,Alloy Steel,14,100,3.5,500
+,Alloy 825 - 15 In,Alloy Steel,15,100,3.5,500
+,Alloy 825 - 16 In,Alloy Steel,16,100,3.5,500
+,Alloy 825 - 17 In,Alloy Steel,17,100,3.5,500
+,Alloy 825 - 18 In,Alloy Steel,18,100,3,500
+,Alloy 825 - 19 In,Alloy Steel,19,100,3,500
+,Alloy 825 - 20 In,Alloy Steel,20,100,3,500
+,Alloy 901 - 1 In,Alloy Steel,1,110,4,500
+,Alloy 901 - 2 In,Alloy Steel,2,110,4,500
+,Alloy 901 - 3 In,Alloy Steel,3,105,4,500
+,Alloy 901 - 4 In,Alloy Steel,4,105,4,500
+,Alloy 901 - 5 In,Alloy Steel,5,105,4,500
+,Alloy 901 - 6 In,Alloy Steel,6,105,4,500
+,Alloy 901 - 7 In,Alloy Steel,7,105,4,500
+,Alloy 901 - 8 In,Alloy Steel,8,105,4,500
+,Alloy 901 - 9 In,Alloy Steel,9,105,4,500
+,Alloy 901 - 10 In,Alloy Steel,10,105,3.5,500
+,Alloy 901 - 11 In,Alloy Steel,11,105,3.5,500
+,Alloy 901 - 12 In,Alloy Steel,12,105,3.5,500
+,Alloy 901 - 13 In,Alloy Steel,13,105,3.5,500
+,Alloy 901 - 14 In,Alloy Steel,14,100,3.5,500
+,Alloy 901 - 15 In,Alloy Steel,15,100,3.5,500
+,Alloy 901 - 16 In,Alloy Steel,16,100,3.5,500
+,Alloy 901 - 17 In,Alloy Steel,17,100,3.5,500
+,Alloy 901 - 18 In,Alloy Steel,18,100,3,500
+,Alloy 901 - 19 In,Alloy Steel,19,100,3,500
+,Alloy 901 - 20 In,Alloy Steel,20,100,3,500
+,Alloy A286 - 1 In,Alloy Steel,1,110,4,500
+,Alloy A286 - 2 In,Alloy Steel,2,110,4,500
+,Alloy A286 - 3 In,Alloy Steel,3,105,4,500
+,Alloy A286 - 4 In,Alloy Steel,4,105,4,500
+,Alloy A286 - 5 In,Alloy Steel,5,105,4,500
+,Alloy A286 - 6 In,Alloy Steel,6,105,4,500
+,Alloy A286 - 7 In,Alloy Steel,7,105,4,500
+,Alloy A286 - 8 In,Alloy Steel,8,105,4,500
+,Alloy A286 - 9 In,Alloy Steel,9,105,4,500
+,Alloy A286 - 10 In,Alloy Steel,10,105,3.5,500
+,Alloy A286 - 11 In,Alloy Steel,11,105,3.5,500
+,Alloy A286 - 12 In,Alloy Steel,12,105,3.5,500
+,Alloy A286 - 13 In,Alloy Steel,13,105,3.5,500
+,Alloy A286 - 14 In,Alloy Steel,14,100,3.5,500
+,Alloy A286 - 15 In,Alloy Steel,15,100,3.5,500
+,Alloy A286 - 16 In,Alloy Steel,16,100,3.5,500
+,Alloy A286 - 17 In,Alloy Steel,17,100,3.5,500
+,Alloy A286 - 18 In,Alloy Steel,18,100,3,500
+,Alloy A286 - 19 In,Alloy Steel,19,100,3,500
+,Alloy A286 - 20 In,Alloy Steel,20,100,3,500
+,Alloy AM350 - 1 In,Alloy Steel,1,110,4,500
+,Alloy AM350 - 2 In,Alloy Steel,2,110,4,500
+,Alloy AM350 - 3 In,Alloy Steel,3,105,4,500
+,Alloy AM350 - 4 In,Alloy Steel,4,105,4,500
+,Alloy AM350 - 5 In,Alloy Steel,5,105,4,500
+,Alloy AM350 - 6 In,Alloy Steel,6,105,4,500
+,Alloy AM350 - 7 In,Alloy Steel,7,105,4,500
+,Alloy AM350 - 8 In,Alloy Steel,8,105,4,500
+,Alloy AM350 - 9 In,Alloy Steel,9,105,4,500
+,Alloy AM350 - 10 In,Alloy Steel,10,105,3.5,500
+,Alloy AM350 - 11 In,Alloy Steel,11,105,3.5,500
+,Alloy AM350 - 12 In,Alloy Steel,12,105,3.5,500
+,Alloy AM350 - 13 In,Alloy Steel,13,105,3.5,500
+,Alloy AM350 - 14 In,Alloy Steel,14,100,3.5,500
+,Alloy AM350 - 15 In,Alloy Steel,15,100,3.5,500
+,Alloy AM350 - 16 In,Alloy Steel,16,100,3.5,500
+,Alloy AM350 - 17 In,Alloy Steel,17,100,3.5,500
+,Alloy AM350 - 18 In,Alloy Steel,18,100,3,500
+,Alloy AM350 - 19 In,Alloy Steel,19,100,3,500
+,Alloy AM350 - 20 In,Alloy Steel,20,100,3,500
+,Alloy AM355 - 1 In,Alloy Steel,1,110,4,500
+,Alloy AM355 - 2 In,Alloy Steel,2,110,4,500
+,Alloy AM355 - 3 In,Alloy Steel,3,105,4,500
+,Alloy AM355 - 4 In,Alloy Steel,4,105,4,500
+,Alloy AM355 - 5 In,Alloy Steel,5,105,4,500
+,Alloy AM355 - 6 In,Alloy Steel,6,105,4,500
+,Alloy AM355 - 7 In,Alloy Steel,7,105,4,500
+,Alloy AM355 - 8 In,Alloy Steel,8,105,4,500
+,Alloy AM355 - 9 In,Alloy Steel,9,105,4,500
+,Alloy AM355 - 10 In,Alloy Steel,10,105,3.5,500
+,Alloy AM355 - 11 In,Alloy Steel,11,105,3.5,500
+,Alloy AM355 - 12 In,Alloy Steel,12,105,3.5,500
+,Alloy AM355 - 13 In,Alloy Steel,13,105,3.5,500
+,Alloy AM355 - 14 In,Alloy Steel,14,100,3.5,500
+,Alloy AM355 - 15 In,Alloy Steel,15,100,3.5,500
+,Alloy AM355 - 16 In,Alloy Steel,16,100,3.5,500
+,Alloy AM355 - 17 In,Alloy Steel,17,100,3.5,500
+,Alloy AM355 - 18 In,Alloy Steel,18,100,3,500
+,Alloy AM355 - 19 In,Alloy Steel,19,100,3,500
+,Alloy AM355 - 20 In,Alloy Steel,20,100,3,500
+,Alloy N-155 - 1 In,Alloy Steel,1,110,4,500
+,Alloy N-155 - 2 In,Alloy Steel,2,110,4,500
+,Alloy N-155 - 3 In,Alloy Steel,3,105,4,500
+,Alloy N-155 - 4 In,Alloy Steel,4,105,4,500
+,Alloy N-155 - 5 In,Alloy Steel,5,105,4,500
+,Alloy N-155 - 6 In,Alloy Steel,6,105,4,500
+,Alloy N-155 - 7 In,Alloy Steel,7,105,4,500
+,Alloy N-155 - 8 In,Alloy Steel,8,105,4,500
+,Alloy N-155 - 9 In,Alloy Steel,9,105,4,500
+,Alloy N-155 - 10 In,Alloy Steel,10,105,3.5,500
+,Alloy N-155 - 11 In,Alloy Steel,11,105,3.5,500
+,Alloy N-155 - 12 In,Alloy Steel,12,105,3.5,500
+,Alloy N-155 - 13 In,Alloy Steel,13,105,3.5,500
+,Alloy N-155 - 14 In,Alloy Steel,14,100,3.5,500
+,Alloy N-155 - 15 In,Alloy Steel,15,100,3.5,500
+,Alloy N-155 - 16 In,Alloy Steel,16,100,3.5,500
+,Alloy N-155 - 17 In,Alloy Steel,17,100,3.5,500
+,Alloy N-155 - 18 In,Alloy Steel,18,100,3,500
+,Alloy N-155 - 19 In,Alloy Steel,19,100,3,500
+,Alloy N-155 - 20 In,Alloy Steel,20,100,3,500
+,Alloy X750 - 1 In,Alloy Steel,1,110,4,500
+,Alloy X750 - 2 In,Alloy Steel,2,110,4,500
+,Alloy X750 - 3 In,Alloy Steel,3,105,4,500
+,Alloy X750 - 4 In,Alloy Steel,4,105,4,500
+,Alloy X750 - 5 In,Alloy Steel,5,105,4,500
+,Alloy X750 - 6 In,Alloy Steel,6,105,4,500
+,Alloy X750 - 7 In,Alloy Steel,7,105,4,500
+,Alloy X750 - 8 In,Alloy Steel,8,105,4,500
+,Alloy X750 - 9 In,Alloy Steel,9,105,4,500
+,Alloy X750 - 10 In,Alloy Steel,10,105,3.5,500
+,Alloy X750 - 11 In,Alloy Steel,11,105,3.5,500
+,Alloy X750 - 12 In,Alloy Steel,12,105,3.5,500
+,Alloy X750 - 13 In,Alloy Steel,13,105,3.5,500
+,Alloy X750 - 14 In,Alloy Steel,14,100,3.5,500
+,Alloy X750 - 15 In,Alloy Steel,15,100,3.5,500
+,Alloy X750 - 16 In,Alloy Steel,16,100,3.5,500
+,Alloy X750 - 17 In,Alloy Steel,17,100,3.5,500
+,Alloy X750 - 18 In,Alloy Steel,18,100,3,500
+,Alloy X750 - 19 In,Alloy Steel,19,100,3,500
+,Alloy X750 - 20 In,Alloy Steel,20,100,3,500
+,Custom 455 - 1 In,Super Alloy Steel,1,100,3,500
+,Custom 455 - 2 In,Super Alloy Steel,2,100,3,500
+,Custom 455 - 3 In,Super Alloy Steel,3,90,3,500
+,Custom 455 - 4 In,Super Alloy Steel,4,90,3,500
+,Custom 455 - 5 In,Super Alloy Steel,5,90,3,500
+,Custom 455 - 6 In,Super Alloy Steel,6,90,3,500
+,Custom 455 - 7 In,Super Alloy Steel,7,80,2,500
+,Custom 455 - 8 In,Super Alloy Steel,8,80,2,500
+,Custom 455 - 9 In,Super Alloy Steel,9,80,2,500
+,Custom 455 - 10 In,Super Alloy Steel,10,80,2,500
+,Custom 455 - 11 In,Super Alloy Steel,11,80,2,500
+,Custom 455 - 12 In,Super Alloy Steel,12,80,2,500
+,Custom 455 - 13 In,Super Alloy Steel,13,80,2,500
+,Custom 455 - 14 In,Super Alloy Steel,14,80,2,500
+,Custom 455 - 15 In,Super Alloy Steel,15,80,2,500
+,Custom 455 - 16 In,Super Alloy Steel,16,80,2,500
+,Custom 455 - 17 In,Super Alloy Steel,17,80,2,500
+,Custom 455 - 18 In,Super Alloy Steel,18,80,2,500
+,Custom 455 - 19 In,Super Alloy Steel,19,80,2,500
+,Custom 455 - 20 In,Super Alloy Steel,20,80,2,500
+,Hastelloy C22 - 1 In,Super Alloy Steel,1,100,3,500
+,Hastelloy C22 - 2 In,Super Alloy Steel,2,100,3,500
+,Hastelloy C22 - 3 In,Super Alloy Steel,3,90,3,500
+,Hastelloy C22 - 4 In,Super Alloy Steel,4,90,3,500
+,Hastelloy C22 - 5 In,Super Alloy Steel,5,90,3,500
+,Hastelloy C22 - 6 In,Super Alloy Steel,6,90,3,500
+,Hastelloy C22 - 7 In,Super Alloy Steel,7,80,2,500
+,Hastelloy C22 - 8 In,Super Alloy Steel,8,80,2,500
+,Hastelloy C22 - 9 In,Super Alloy Steel,9,80,2,500
+,Hastelloy C22 - 10 In,Super Alloy Steel,10,80,2,500
+,Hastelloy C22 - 11 In,Super Alloy Steel,11,80,2,500
+,Hastelloy C22 - 12 In,Super Alloy Steel,12,80,2,500
+,Hastelloy C22 - 13 In,Super Alloy Steel,13,80,2,500
+,Hastelloy C22 - 14 In,Super Alloy Steel,14,80,2,500
+,Hastelloy C22 - 15 In,Super Alloy Steel,15,80,2,500
+,Hastelloy C22 - 16 In,Super Alloy Steel,16,80,2,500
+,Hastelloy C22 - 17 In,Super Alloy Steel,17,80,2,500
+,Hastelloy C22 - 18 In,Super Alloy Steel,18,80,2,500
+,Hastelloy C22 - 19 In,Super Alloy Steel,19,80,2,500
+,Hastelloy C22 - 20 In,Super Alloy Steel,20,80,2,500
+,Hastelloy C276 - 1 In,Super Alloy Steel,1,100,3,500
+,Hastelloy C276 - 2 In,Super Alloy Steel,2,100,3,500
+,Hastelloy C276 - 3 In,Super Alloy Steel,3,90,3,500
+,Hastelloy C276 - 4 In,Super Alloy Steel,4,90,3,500
+,Hastelloy C276 - 5 In,Super Alloy Steel,5,90,3,500
+,Hastelloy C276 - 6 In,Super Alloy Steel,6,90,3,500
+,Hastelloy C276 - 7 In,Super Alloy Steel,7,80,2,500
+,Hastelloy C276 - 8 In,Super Alloy Steel,8,80,2,500
+,Hastelloy C276 - 9 In,Super Alloy Steel,9,80,2,500
+,Hastelloy C276 - 10 In,Super Alloy Steel,10,80,2,500
+,Hastelloy C276 - 11 In,Super Alloy Steel,11,80,2,500
+,Hastelloy C276 - 12 In,Super Alloy Steel,12,80,2,500
+,Hastelloy C276 - 13 In,Super Alloy Steel,13,80,2,500
+,Hastelloy C276 - 14 In,Super Alloy Steel,14,80,2,500
+,Hastelloy C276 - 15 In,Super Alloy Steel,15,80,2,500
+,Hastelloy C276 - 16 In,Super Alloy Steel,16,80,2,500
+,Hastelloy C276 - 17 In,Super Alloy Steel,17,80,2,500
+,Hastelloy C276 - 18 In,Super Alloy Steel,18,80,2,500
+,Hastelloy C276 - 19 In,Super Alloy Steel,19,80,2,500
+,Hastelloy C276 - 20 In,Super Alloy Steel,20,80,2,500
+,Hastelloy X - 1 In,Super Alloy Steel,1,100,3,500
+,Hastelloy X - 2 In,Super Alloy Steel,2,100,3,500
+,Hastelloy X - 3 In,Super Alloy Steel,3,90,3,500
+,Hastelloy X - 4 In,Super Alloy Steel,4,90,3,500
+,Hastelloy X - 5 In,Super Alloy Steel,5,90,3,500
+,Hastelloy X - 6 In,Super Alloy Steel,6,90,3,500
+,Hastelloy X - 7 In,Super Alloy Steel,7,80,2,500
+,Hastelloy X - 8 In,Super Alloy Steel,8,80,2,500
+,Hastelloy X - 9 In,Super Alloy Steel,9,80,2,500
+,Hastelloy X - 10 In,Super Alloy Steel,10,80,2,500
+,Hastelloy X - 11 In,Super Alloy Steel,11,80,2,500
+,Hastelloy X - 12 In,Super Alloy Steel,12,80,2,500
+,Hastelloy X - 13 In,Super Alloy Steel,13,80,2,500
+,Hastelloy X - 14 In,Super Alloy Steel,14,80,2,500
+,Hastelloy X - 15 In,Super Alloy Steel,15,80,2,500
+,Hastelloy X - 16 In,Super Alloy Steel,16,80,2,500
+,Hastelloy X - 17 In,Super Alloy Steel,17,80,2,500
+,Hastelloy X - 18 In,Super Alloy Steel,18,80,2,500
+,Hastelloy X - 19 In,Super Alloy Steel,19,80,2,500
+,Hastelloy X - 20 In,Super Alloy Steel,20,80,2,500
+,Haynes 242 - 1 In,Super Alloy Steel,1,100,3,500
+,Haynes 242 - 2 In,Super Alloy Steel,2,100,3,500
+,Haynes 242 - 3 In,Super Alloy Steel,3,90,3,500
+,Haynes 242 - 4 In,Super Alloy Steel,4,90,3,500
+,Haynes 242 - 5 In,Super Alloy Steel,5,90,3,500
+,Haynes 242 - 6 In,Super Alloy Steel,6,90,3,500
+,Haynes 242 - 7 In,Super Alloy Steel,7,80,2,500
+,Haynes 242 - 8 In,Super Alloy Steel,8,80,2,500
+,Haynes 242 - 9 In,Super Alloy Steel,9,80,2,500
+,Haynes 242 - 10 In,Super Alloy Steel,10,80,2,500
+,Haynes 242 - 11 In,Super Alloy Steel,11,80,2,500
+,Haynes 242 - 12 In,Super Alloy Steel,12,80,2,500
+,Haynes 242 - 13 In,Super Alloy Steel,13,80,2,500
+,Haynes 242 - 14 In,Super Alloy Steel,14,80,2,500
+,Haynes 242 - 15 In,Super Alloy Steel,15,80,2,500
+,Haynes 242 - 16 In,Super Alloy Steel,16,80,2,500
+,Haynes 242 - 17 In,Super Alloy Steel,17,80,2,500
+,Haynes 242 - 18 In,Super Alloy Steel,18,80,2,500
+,Haynes 242 - 19 In,Super Alloy Steel,19,80,2,500
+,Haynes 242 - 20 In,Super Alloy Steel,20,80,2,500
+,HyMu 80 - 1 In,Super Alloy Steel,1,100,3,500
+,HyMu 80 - 2 In,Super Alloy Steel,2,100,3,500
+,HyMu 80 - 3 In,Super Alloy Steel,3,90,3,500
+,HyMu 80 - 4 In,Super Alloy Steel,4,90,3,500
+,HyMu 80 - 5 In,Super Alloy Steel,5,90,3,500
+,HyMu 80 - 6 In,Super Alloy Steel,6,90,3,500
+,HyMu 80 - 7 In,Super Alloy Steel,7,80,2,500
+,HyMu 80 - 8 In,Super Alloy Steel,8,80,2,500
+,HyMu 80 - 9 In,Super Alloy Steel,9,80,2,500
+,HyMu 80 - 10 In,Super Alloy Steel,10,80,2,500
+,HyMu 80 - 11 In,Super Alloy Steel,11,80,2,500
+,HyMu 80 - 12 In,Super Alloy Steel,12,80,2,500
+,HyMu 80 - 13 In,Super Alloy Steel,13,80,2,500
+,HyMu 80 - 14 In,Super Alloy Steel,14,80,2,500
+,HyMu 80 - 15 In,Super Alloy Steel,15,80,2,500
+,HyMu 80 - 16 In,Super Alloy Steel,16,80,2,500
+,HyMu 80 - 17 In,Super Alloy Steel,17,80,2,500
+,HyMu 80 - 18 In,Super Alloy Steel,18,80,2,500
+,HyMu 80 - 19 In,Super Alloy Steel,19,80,2,500
+,HyMu 80 - 20 In,Super Alloy Steel,20,80,2,500
+,Invar 36 - 1 In,Super Alloy Steel,1,100,3,500
+,Invar 36 - 2 In,Super Alloy Steel,2,100,3,500
+,Invar 36 - 3 In,Super Alloy Steel,3,90,3,500
+,Invar 36 - 4 In,Super Alloy Steel,4,90,3,500
+,Invar 36 - 5 In,Super Alloy Steel,5,90,3,500
+,Invar 36 - 6 In,Super Alloy Steel,6,90,3,500
+,Invar 36 - 7 In,Super Alloy Steel,7,80,2,500
+,Invar 36 - 8 In,Super Alloy Steel,8,80,2,500
+,Invar 36 - 9 In,Super Alloy Steel,9,80,2,500
+,Invar 36 - 10 In,Super Alloy Steel,10,80,2,500
+,Invar 36 - 11 In,Super Alloy Steel,11,80,2,500
+,Invar 36 - 12 In,Super Alloy Steel,12,80,2,500
+,Invar 36 - 13 In,Super Alloy Steel,13,80,2,500
+,Invar 36 - 14 In,Super Alloy Steel,14,80,2,500
+,Invar 36 - 15 In,Super Alloy Steel,15,80,2,500
+,Invar 36 - 16 In,Super Alloy Steel,16,80,2,500
+,Invar 36 - 17 In,Super Alloy Steel,17,80,2,500
+,Invar 36 - 18 In,Super Alloy Steel,18,80,2,500
+,Invar 36 - 19 In,Super Alloy Steel,19,80,2,500
+,Invar 36 - 20 In,Super Alloy Steel,20,80,2,500
+,Invar 42 - 1 In,Super Alloy Steel,1,100,3,500
+,Invar 42 - 2 In,Super Alloy Steel,2,100,3,500
+,Invar 42 - 3 In,Super Alloy Steel,3,90,3,500
+,Invar 42 - 4 In,Super Alloy Steel,4,90,3,500
+,Invar 42 - 5 In,Super Alloy Steel,5,90,3,500
+,Invar 42 - 6 In,Super Alloy Steel,6,90,3,500
+,Invar 42 - 7 In,Super Alloy Steel,7,80,2,500
+,Invar 42 - 8 In,Super Alloy Steel,8,80,2,500
+,Invar 42 - 9 In,Super Alloy Steel,9,80,2,500
+,Invar 42 - 10 In,Super Alloy Steel,10,80,2,500
+,Invar 42 - 11 In,Super Alloy Steel,11,80,2,500
+,Invar 42 - 12 In,Super Alloy Steel,12,80,2,500
+,Invar 42 - 13 In,Super Alloy Steel,13,80,2,500
+,Invar 42 - 14 In,Super Alloy Steel,14,80,2,500
+,Invar 42 - 15 In,Super Alloy Steel,15,80,2,500
+,Invar 42 - 16 In,Super Alloy Steel,16,80,2,500
+,Invar 42 - 17 In,Super Alloy Steel,17,80,2,500
+,Invar 42 - 18 In,Super Alloy Steel,18,80,2,500
+,Invar 42 - 19 In,Super Alloy Steel,19,80,2,500
+,Invar 42 - 20 In,Super Alloy Steel,20,80,2,500
+,Kovar - 1 In,Super Alloy Steel,1,100,3,500
+,Kovar - 2 In,Super Alloy Steel,2,100,3,500
+,Kovar - 3 In,Super Alloy Steel,3,90,3,500
+,Kovar - 4 In,Super Alloy Steel,4,90,3,500
+,Kovar - 5 In,Super Alloy Steel,5,90,3,500
+,Kovar - 6 In,Super Alloy Steel,6,90,3,500
+,Kovar - 7 In,Super Alloy Steel,7,80,2,500
+,Kovar - 8 In,Super Alloy Steel,8,80,2,500
+,Kovar - 9 In,Super Alloy Steel,9,80,2,500
+,Kovar - 10 In,Super Alloy Steel,10,80,2,500
+,Kovar - 11 In,Super Alloy Steel,11,80,2,500
+,Kovar - 12 In,Super Alloy Steel,12,80,2,500
+,Kovar - 13 In,Super Alloy Steel,13,80,2,500
+,Kovar - 14 In,Super Alloy Steel,14,80,2,500
+,Kovar - 15 In,Super Alloy Steel,15,80,2,500
+,Kovar - 16 In,Super Alloy Steel,16,80,2,500
+,Kovar - 17 In,Super Alloy Steel,17,80,2,500
+,Kovar - 18 In,Super Alloy Steel,18,80,2,500
+,Kovar - 19 In,Super Alloy Steel,19,80,2,500
+,Kovar - 20 In,Super Alloy Steel,20,80,2,500
+,L605 - 1 In,Super Alloy Steel,1,110,4,500
+,L605 - 2 In,Super Alloy Steel,2,110,4,500
+,L605 - 3 In,Super Alloy Steel,3,105,4,500
+,L605 - 4 In,Super Alloy Steel,4,105,4,500
+,L605 - 5 In,Super Alloy Steel,5,105,4,500
+,L605 - 6 In,Super Alloy Steel,6,105,4,500
+,L605 - 7 In,Super Alloy Steel,7,105,4,500
+,L605 - 8 In,Super Alloy Steel,8,105,4,500
+,L605 - 9 In,Super Alloy Steel,9,105,4,500
+,L605 - 10 In,Super Alloy Steel,10,105,3.5,500
+,L605 - 11 In,Super Alloy Steel,11,105,3.5,500
+,L605 - 12 In,Super Alloy Steel,12,105,3.5,500
+,L605 - 13 In,Super Alloy Steel,13,105,3.5,500
+,L605 - 14 In,Super Alloy Steel,14,100,3.5,500
+,L605 - 15 In,Super Alloy Steel,15,100,3.5,500
+,L605 - 16 In,Super Alloy Steel,16,100,3.5,500
+,L605 - 17 In,Super Alloy Steel,17,100,3.5,500
+,L605 - 18 In,Super Alloy Steel,18,100,3,500
+,L605 - 19 In,Super Alloy Steel,19,100,3,500
+,L605 - 20 In,Super Alloy Steel,20,100,3,500
+,Monel 400 - 1 In,Super Alloy Steel,1,110,4,500
+,Monel 400 - 2 In,Super Alloy Steel,2,110,4,500
+,Monel 400 - 3 In,Super Alloy Steel,3,105,4,500
+,Monel 400 - 4 In,Super Alloy Steel,4,105,4,500
+,Monel 400 - 5 In,Super Alloy Steel,5,105,4,500
+,Monel 400 - 6 In,Super Alloy Steel,6,105,4,500
+,Monel 400 - 7 In,Super Alloy Steel,7,105,4,500
+,Monel 400 - 8 In,Super Alloy Steel,8,105,4,500
+,Monel 400 - 9 In,Super Alloy Steel,9,105,4,500
+,Monel 400 - 10 In,Super Alloy Steel,10,105,3.5,500
+,Monel 400 - 11 In,Super Alloy Steel,11,105,3.5,500
+,Monel 400 - 12 In,Super Alloy Steel,12,105,3.5,500
+,Monel 400 - 13 In,Super Alloy Steel,13,105,3.5,500
+,Monel 400 - 14 In,Super Alloy Steel,14,100,3.5,500
+,Monel 400 - 15 In,Super Alloy Steel,15,100,3.5,500
+,Monel 400 - 16 In,Super Alloy Steel,16,100,3.5,500
+,Monel 400 - 17 In,Super Alloy Steel,17,100,3.5,500
+,Monel 400 - 18 In,Super Alloy Steel,18,100,3,500
+,Monel 400 - 19 In,Super Alloy Steel,19,100,3,500
+,Monel 400 - 20 In,Super Alloy Steel,20,100,3,500
+,Monel K500 - 1 In,Super Alloy Steel,1,110,4,500
+,Monel K500 - 2 In,Super Alloy Steel,2,110,4,500
+,Monel K500 - 3 In,Super Alloy Steel,3,105,4,500
+,Monel K500 - 4 In,Super Alloy Steel,4,105,4,500
+,Monel K500 - 5 In,Super Alloy Steel,5,105,4,500
+,Monel K500 - 6 In,Super Alloy Steel,6,105,4,500
+,Monel K500 - 7 In,Super Alloy Steel,7,105,4,500
+,Monel K500 - 8 In,Super Alloy Steel,8,105,4,500
+,Monel K500 - 9 In,Super Alloy Steel,9,105,4,500
+,Monel K500 - 10 In,Super Alloy Steel,10,105,3.5,500
+,Monel K500 - 11 In,Super Alloy Steel,11,105,3.5,500
+,Monel K500 - 12 In,Super Alloy Steel,12,105,3.5,500
+,Monel K500 - 13 In,Super Alloy Steel,13,105,3.5,500
+,Monel K500 - 14 In,Super Alloy Steel,14,100,3.5,500
+,Monel K500 - 15 In,Super Alloy Steel,15,100,3.5,500
+,Monel K500 - 16 In,Super Alloy Steel,16,100,3.5,500
+,Monel K500 - 17 In,Super Alloy Steel,17,100,3.5,500
+,Monel K500 - 18 In,Super Alloy Steel,18,100,3,500
+,Monel K500 - 19 In,Super Alloy Steel,19,100,3,500
+,Monel K500 - 20 In,Super Alloy Steel,20,100,3,500
+,Mu-metal - 1 In,Super Alloy Steel,1,110,4,500
+,Mu-metal - 2 In,Super Alloy Steel,2,110,4,500
+,Mu-metal - 3 In,Super Alloy Steel,3,105,4,500
+,Mu-metal - 4 In,Super Alloy Steel,4,105,4,500
+,Mu-metal - 5 In,Super Alloy Steel,5,105,4,500
+,Mu-metal - 6 In,Super Alloy Steel,6,105,4,500
+,Mu-metal - 7 In,Super Alloy Steel,7,105,4,500
+,Mu-metal - 8 In,Super Alloy Steel,8,105,4,500
+,Mu-metal - 9 In,Super Alloy Steel,9,105,4,500
+,Mu-metal - 10 In,Super Alloy Steel,10,105,3.5,500
+,Mu-metal - 11 In,Super Alloy Steel,11,105,3.5,500
+,Mu-metal - 12 In,Super Alloy Steel,12,105,3.5,500
+,Mu-metal - 13 In,Super Alloy Steel,13,105,3.5,500
+,Mu-metal - 14 In,Super Alloy Steel,14,100,3.5,500
+,Mu-metal - 15 In,Super Alloy Steel,15,100,3.5,500
+,Mu-metal - 16 In,Super Alloy Steel,16,100,3.5,500
+,Mu-metal - 17 In,Super Alloy Steel,17,100,3.5,500
+,Mu-metal - 18 In,Super Alloy Steel,18,100,3,500
+,Mu-metal - 19 In,Super Alloy Steel,19,100,3,500
+,Mu-metal - 20 In,Super Alloy Steel,20,100,3,500
+,Nickel 200 - 1 In,Super Alloy Steel,1,110,4,500
+,Nickel 200 - 2 In,Super Alloy Steel,2,110,4,500
+,Nickel 200 - 3 In,Super Alloy Steel,3,105,4,500
+,Nickel 200 - 4 In,Super Alloy Steel,4,105,4,500
+,Nickel 200 - 5 In,Super Alloy Steel,5,105,4,500
+,Nickel 200 - 6 In,Super Alloy Steel,6,105,4,500
+,Nickel 200 - 7 In,Super Alloy Steel,7,105,4,500
+,Nickel 200 - 8 In,Super Alloy Steel,8,105,4,500
+,Nickel 200 - 9 In,Super Alloy Steel,9,105,4,500
+,Nickel 200 - 10 In,Super Alloy Steel,10,105,3.5,500
+,Nickel 200 - 11 In,Super Alloy Steel,11,105,3.5,500
+,Nickel 200 - 12 In,Super Alloy Steel,12,105,3.5,500
+,Nickel 200 - 13 In,Super Alloy Steel,13,105,3.5,500
+,Nickel 200 - 14 In,Super Alloy Steel,14,100,3.5,500
+,Nickel 200 - 15 In,Super Alloy Steel,15,100,3.5,500
+,Nickel 200 - 16 In,Super Alloy Steel,16,100,3.5,500
+,Nickel 200 - 17 In,Super Alloy Steel,17,100,3.5,500
+,Nickel 200 - 18 In,Super Alloy Steel,18,100,3,500
+,Nickel 200 - 19 In,Super Alloy Steel,19,100,3,500
+,Nickel 200 - 20 In,Super Alloy Steel,20,100,3,500
+,Permendur 2V - 1 In,Super Alloy Steel,1,110,4,500
+,Permendur 2V - 2 In,Super Alloy Steel,2,110,4,500
+,Permendur 2V - 3 In,Super Alloy Steel,3,105,4,500
+,Permendur 2V - 4 In,Super Alloy Steel,4,105,4,500
+,Permendur 2V - 5 In,Super Alloy Steel,5,105,4,500
+,Permendur 2V - 6 In,Super Alloy Steel,6,105,4,500
+,Permendur 2V - 7 In,Super Alloy Steel,7,105,4,500
+,Permendur 2V - 8 In,Super Alloy Steel,8,105,4,500
+,Permendur 2V - 9 In,Super Alloy Steel,9,105,4,500
+,Permendur 2V - 10 In,Super Alloy Steel,10,105,3.5,500
+,Permendur 2V - 11 In,Super Alloy Steel,11,105,3.5,500
+,Permendur 2V - 12 In,Super Alloy Steel,12,105,3.5,500
+,Permendur 2V - 13 In,Super Alloy Steel,13,105,3.5,500
+,Permendur 2V - 14 In,Super Alloy Steel,14,100,3.5,500
+,Permendur 2V - 15 In,Super Alloy Steel,15,100,3.5,500
+,Permendur 2V - 16 In,Super Alloy Steel,16,100,3.5,500
+,Permendur 2V - 17 In,Super Alloy Steel,17,100,3.5,500
+,Permendur 2V - 18 In,Super Alloy Steel,18,100,3,500
+,Permendur 2V - 19 In,Super Alloy Steel,19,100,3,500
+,Permendur 2V - 20 In,Super Alloy Steel,20,100,3,500
+,Rene 41 - 1 In,Super Alloy Steel,1,110,4,500
+,Rene 41 - 2 In,Super Alloy Steel,2,110,4,500
+,Rene 41 - 3 In,Super Alloy Steel,3,105,4,500
+,Rene 41 - 4 In,Super Alloy Steel,4,105,4,500
+,Rene 41 - 5 In,Super Alloy Steel,5,105,4,500
+,Rene 41 - 6 In,Super Alloy Steel,6,105,4,500
+,Rene 41 - 7 In,Super Alloy Steel,7,105,4,500
+,Rene 41 - 8 In,Super Alloy Steel,8,105,4,500
+,Rene 41 - 9 In,Super Alloy Steel,9,105,4,500
+,Rene 41 - 10 In,Super Alloy Steel,10,105,3.5,500
+,Rene 41 - 11 In,Super Alloy Steel,11,105,3.5,500
+,Rene 41 - 12 In,Super Alloy Steel,12,105,3.5,500
+,Rene 41 - 13 In,Super Alloy Steel,13,105,3.5,500
+,Rene 41 - 14 In,Super Alloy Steel,14,100,3.5,500
+,Rene 41 - 15 In,Super Alloy Steel,15,100,3.5,500
+,Rene 41 - 16 In,Super Alloy Steel,16,100,3.5,500
+,Rene 41 - 17 In,Super Alloy Steel,17,100,3.5,500
+,Rene 41 - 18 In,Super Alloy Steel,18,100,3,500
+,Rene 41 - 19 In,Super Alloy Steel,19,100,3,500
+,Rene 41 - 20 In,Super Alloy Steel,20,100,3,500
+,Super Invar 32 - 1 In,Super Alloy Steel,1,110,4,500
+,Super Invar 32 - 2 In,Super Alloy Steel,2,110,4,500
+,Super Invar 32 - 3 In,Super Alloy Steel,3,105,4,500
+,Super Invar 32 - 4 In,Super Alloy Steel,4,105,4,500
+,Super Invar 32 - 5 In,Super Alloy Steel,5,105,4,500
+,Super Invar 32 - 6 In,Super Alloy Steel,6,105,4,500
+,Super Invar 32 - 7 In,Super Alloy Steel,7,105,4,500
+,Super Invar 32 - 8 In,Super Alloy Steel,8,105,4,500
+,Super Invar 32 - 9 In,Super Alloy Steel,9,105,4,500
+,Super Invar 32 - 10 In,Super Alloy Steel,10,105,3.5,500
+,Super Invar 32 - 11 In,Super Alloy Steel,11,105,3.5,500
+,Super Invar 32 - 12 In,Super Alloy Steel,12,105,3.5,500
+,Super Invar 32 - 13 In,Super Alloy Steel,13,105,3.5,500
+,Super Invar 32 - 14 In,Super Alloy Steel,14,100,3.5,500
+,Super Invar 32 - 15 In,Super Alloy Steel,15,100,3.5,500
+,Super Invar 32 - 16 In,Super Alloy Steel,16,100,3.5,500
+,Super Invar 32 - 17 In,Super Alloy Steel,17,100,3.5,500
+,Super Invar 32 - 18 In,Super Alloy Steel,18,100,3,500
+,Super Invar 32 - 19 In,Super Alloy Steel,19,100,3,500
+,Super Invar 32 - 20 In,Super Alloy Steel,20,100,3,500
+,Waspaloy - 1 In,Super Alloy Steel,1,110,4,500
+,Waspaloy - 2 In,Super Alloy Steel,2,110,4,500
+,Waspaloy - 3 In,Super Alloy Steel,3,105,4,500
+,Waspaloy - 4 In,Super Alloy Steel,4,105,4,500
+,Waspaloy - 5 In,Super Alloy Steel,5,105,4,500
+,Waspaloy - 6 In,Super Alloy Steel,6,105,4,500
+,Waspaloy - 7 In,Super Alloy Steel,7,105,4,500
+,Waspaloy - 8 In,Super Alloy Steel,8,105,4,500
+,Waspaloy - 9 In,Super Alloy Steel,9,105,4,500
+,Waspaloy - 10 In,Super Alloy Steel,10,105,3.5,500
+,Waspaloy - 11 In,Super Alloy Steel,11,105,3.5,500
+,Waspaloy - 12 In,Super Alloy Steel,12,105,3.5,500
+,Waspaloy - 13 In,Super Alloy Steel,13,105,3.5,500
+,Waspaloy - 14 In,Super Alloy Steel,14,100,3.5,500
+,Waspaloy - 15 In,Super Alloy Steel,15,100,3.5,500
+,Waspaloy - 16 In,Super Alloy Steel,16,100,3.5,500
+,Waspaloy - 17 In,Super Alloy Steel,17,100,3.5,500
+,Waspaloy - 18 In,Super Alloy Steel,18,100,3,500
+,Waspaloy - 19 In,Super Alloy Steel,19,100,3,500
+,Waspaloy - 20 In,Super Alloy Steel,20,100,3,500

--- a/mongodb/data/upload_materials.py
+++ b/mongodb/data/upload_materials.py
@@ -1,0 +1,37 @@
+import pymongo
+import csv
+import re
+
+db_name = 'machine_objects'
+client = pymongo.MongoClient('localhost', 27017)
+collection_materials = client[db_name].materials
+
+upload_materials(collection_materials)
+
+def nwd(name):
+    m = re.search(r'(.*?)\s*(\d+)\s+In', name)
+    if m:
+        return m.group(1)
+    else:
+        return name
+
+def upload_materials(collection):
+    with open('/etc/mongodb/data/MaterialLibrary.csv','r') as infile:
+        reader = csv.DictReader(infile)
+        for row in reader:
+            print(row)
+            collection.insert_one({
+                'name':row['NAME'],
+                'category':row['CLASS'],
+                'diameter':float(row['SIZE']),
+                'blade_speed':float(row['BLADE SPEED']),
+                'chip_removal_rate':float(row['CHIP REMOVAL RATE']),
+                'force':float(row['FORCE']),
+                'name_without_diameter':nwd(row['NAME'])
+            })
+                
+if __name__ == '__main__':
+    client = pymongo.MongoClient('localhost', 27017)
+    collection_materials = client['machine_objects'].materials
+    collection_materials.delete_many({})
+    upload_materials(collection_materials)

--- a/ods/config/odscfg.yaml
+++ b/ods/config/odscfg.yaml
@@ -2,5 +2,5 @@ host: 0.0.0.0
 port: 9625
 object_definitions_file_path: db_object_definitions.json
 log_severity_level: info
-mongodb_host: localhost
+mongodb_host: mongodb
 mongodb_port: 27017

--- a/ssClean.sh
+++ b/ssClean.sh
@@ -13,7 +13,7 @@ Help(){
     echo "-H                Uninstall the HEMsaw adapter application"
     echo "-A                Uninstall the MTConnect Agent application"
     echo "-M                Uninstall the MQTT Broker application"
-    echo "-O		    Uninstall the HEMsaw ods application"
+    echo "-O		        Uninstall the HEMsaw ods application"
     echo "-S	            Uninstall the HEMSaw MongoDB application"
     echo "-D                Uninstall Docker"
     echo "-h                Print this Help."

--- a/ssClean.sh
+++ b/ssClean.sh
@@ -8,12 +8,13 @@ Help(){
     echo "This function uninstalls HEMSaw MTConnect-SmartAdapter, ODS, MTconnect Agent and MQTT."
     echo "Any associated device files for MTConnect and Adapter files are deleted as per this repo."
     echo
-    echo "Syntax: ssClean.sh [-H|-A|-M|-O|-D|-h]"
+    echo "Syntax: ssClean.sh [-H|-A|-M|-O|-S|-D|-h]"
     echo "options:"
     echo "-H                Uninstall the HEMsaw adapter application"
     echo "-A                Uninstall the MTConnect Agent application"
     echo "-M                Uninstall the MQTT Broker application"
-    echo "-O		        Uninstall the HEMsaw ods application"
+    echo "-O		    Uninstall the HEMsaw ods application"
+    echo "-S	            Uninstall the HEMSaw MongoDB application"
     echo "-D                Uninstall Docker"
     echo "-h                Print this Help."
 }
@@ -66,6 +67,13 @@ Uninstall_ODS(){
     echo ""
 }
 
+Uninstall_Mongodb(){
+    echo "Uninstalling Mongodb files..."
+    rm -rf /etc/mongodb/
+    echo "<<Done>>"
+    echo ""
+}
+
 Uninstall_Docker(){
     echo "Shutting down any old Docker containers"
     docker-compose down
@@ -90,13 +98,14 @@ run_uninstall_adapter=false
 run_uninstall_agent=false
 run_uninstall_mqtt=false
 run_uninstall_ods=false
+run_uninstall_mongodb=false
 run_uninstall_docker=false
 
 ############################################################
 # Process the input options. Add options as needed.        #
 ############################################################
 # Get the options
-while getopts ":HAMDhO" option; do
+while getopts ":HAMDhOS" option; do
     case ${option} in
         h) # display Help
             Help
@@ -109,6 +118,8 @@ while getopts ":HAMDhO" option; do
             run_uninstall_mqtt=true;;
         O) # uninstall the ODS
             run_uninstall_ods=true;;
+        S) # uninstall the mongodb
+	    run_uninstall_mongodb=true;;
         D) # uninstall Docker
             run_uninstall_docker=true;;
         \?) # Invalid option
@@ -142,6 +153,7 @@ echo "uninstall Adapter set to run = "$run_uninstall_adapter
 echo "uninstall MTConnect Agent set to run = "$run_uninstall_agent
 echo "uninstall MQTT Broker set to run = "$run_uninstall_mqtt
 echo "uninstall ODS set to run = "$run_uninstall_ods
+echo "uninstall Mongodb set to run="$run_uninstall_mongodb
 echo "uninstall Docker set to run = "$run_uninstall_docker
 
 echo ""
@@ -156,6 +168,9 @@ if $run_uninstall_mqtt; then
 fi
 if $run_uninstall_ods; then
     Uninstall_ODS
+fi
+if $run_uninstall_mongodb; then
+    Uninstall_Mongodb
 fi
 if $run_uninstall_docker; then
     Uninstall_Docker

--- a/ssInstall.sh
+++ b/ssInstall.sh
@@ -70,6 +70,14 @@ InstallODS(){
     chown -R 1000:1000 /etc/ods/
 }
 
+InstallMongodb(){
+    echo "Installing Mongodb..."
+    mkdir -p /etc/mongodb/
+    mkdir -p /etc/mongodb/config/
+    cp -r ./mongodb/config/* /etc/mongodb/config/
+    chown -R 1000:1000 /etc/mongodb/
+}
+
 InstallDocker(){
     echo "Installing Docker..."
     apt update
@@ -113,10 +121,11 @@ else
 fi
 echo ""
 
-if systemctl is-active --quiet adapter || systemctl is-active --quiet ods; then
-    echo "Adapter and/or ODS is running as a systemd service, stopping the systemd services.."
+if systemctl is-active --quiet adapter || systemctl is-active --quiet ods || systemctl is-active --quiet mongod; then
+    echo "Adapter, ODS and/or Mongodb is running as a systemd service, stopping the systemd services.."
     systemctl stop adapter
     systemctl stop ods
+    systemctl stop mongod
     #exit 1
     #Optionally we can stop the Adapter and/or ODS systemd services
     #sudo systemctl stop adapter
@@ -168,6 +177,7 @@ echo ""
 InstallAdapter
 InstallMTCAgent
 InstallODS
+InstallMongodb
 InstallDocker
     
 

--- a/ssInstall.sh
+++ b/ssInstall.sh
@@ -74,8 +74,15 @@ InstallMongodb(){
     echo "Installing Mongodb..."
     mkdir -p /etc/mongodb/
     mkdir -p /etc/mongodb/config/
+    mkdir -p /etc/mongodb/data/
+    mkdir -p /etc/mongodb/data/db
     cp -r ./mongodb/config/* /etc/mongodb/config/
+    cp -r ./mongodb/data/* /etc/mongodb/data/
     chown -R 1000:1000 /etc/mongodb/
+
+    sudo pip3 install pyaml
+    sudo pip3 install pymongo
+    sudo python3 /etc/mongodb/data/upload_materials.py
 }
 
 InstallDocker(){

--- a/ssStatus.sh
+++ b/ssStatus.sh
@@ -2,6 +2,6 @@
 
 if [[ $(id -u) -ne 0 ]] ; then echo "Please run bash ssStatus.sh as sudo" ; exit 1 ; fi
 
-echo "Docker container status for HEMSaw MTConnect-SmartAdapter, MTConnect Agent, Mosquitto, ODS and Watchtower..."
+echo "Docker container status for HEMSaw MTConnect-SmartAdapter, MTConnect Agent, Mosquitto, ODS, Mongodb and Watchtower..."
 docker-compose ps
 echo "<<DONE>>"

--- a/ssUpgrade.sh
+++ b/ssUpgrade.sh
@@ -8,7 +8,7 @@ Help(){
     echo "This function updates HEMSaw MTConnect-SmartAdapter, ODS, MTconnect Agent and MQTT."
     echo "Any associated device files for MTConnect and Adapter files are updated as per this repo."
     echo
-    echo "Syntax: ssUpgrade.sh [-H|-a File_Name|-A|-d File_Name|-u Serial_number|-M|-O|-S|-h]"
+    echo "Syntax: ssUpgrade.sh [-H|-a File_Name|-A|-d File_Name|-u Serial_number|-M|-O|-S|-m|-h]"
     echo "options:"
     echo "-H                Update the HEMsaw adapter application"
     echo "-a File_Name      Declare the afg file name; Defaults to - SmartSaw_DC_HA.afg"
@@ -16,8 +16,8 @@ Help(){
     echo "-d File_Name      Declare the MTConnect agent device file name; Defaults to - SmartSaw_DC_HA.xml"
     echo "-u Serial_number  Declare the serial number for the uuid; Defaults to - SmartSaw"
     echo "-M                Update the MQTT broker application"
-    echo "-O		    Update the HEMsaw ODS application"
-    echo "-S		    Update the HEMsaw MongoDB application"
+    echo "-O                Update the HEMsaw ODS application"
+    echo "-S                Update the HEMsaw MongoDB application"
     echo "-m                Update the MongoDB database with default materials"
     echo "-h                Print this Help."
 }

--- a/ssUpgrade.sh
+++ b/ssUpgrade.sh
@@ -16,8 +16,8 @@ Help(){
     echo "-d File_Name      Declare the MTConnect agent device file name; Defaults to - SmartSaw_DC_HA.xml"
     echo "-u Serial_number  Declare the serial number for the uuid; Defaults to - SmartSaw"
     echo "-M                Update the MQTT broker application"
-    echo "-O		        Update the HEMsaw ODS application"
-    echo "-S		        Update the HEMsaw MongoDB application"
+    echo "-O		    Update the HEMsaw ODS application"
+    echo "-S		    Update the HEMsaw MongoDB application"
     echo "-m                Update the MongoDB database with default materials"
     echo "-h                Print this Help."
 }


### PR DESCRIPTION
Jira Id: EP4US7
- Updated docker-compose.yml script to support MongoDB
- Updated ssInstall, ssUpgrade, ssClean and ssStatus scripts
- Added Functional Specification Document for MongoDB Dockerization with Docker-Compose
