### PR TITLE
Feature/mqtt UUID

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,11 @@ For build level release notes see https://github.com/mtconnect/cppagent/
 
 ## [Unreleased]
 
+## [2.1.1] - 2024/08/29 - Max Harris
+### Changed
+
+- modified the bridge to set the uuid as  the serial number declared in the env.sh or from the command line.
+
 ## [2.1.0] - 2024/08/21 - Max Harris
 ### Added
 

--- a/mqtt/config/mosq_bridge.conf
+++ b/mqtt/config/mosq_bridge.conf
@@ -23,7 +23,7 @@ topic # out 1 monitor/ monitor/hemsaw/ok1/
 
 #The remote_clientid must be universally unique,
 #for all local mosquitto connected to the same edge broker
-#remote_clientid broker1
+#set "remote_clientid broker1" as unique
 remote_username ssconnect-local-broker
 remote_password pwssconnect-local-broker
 

--- a/mqtt/config/mosq_bridge.conf
+++ b/mqtt/config/mosq_bridge.conf
@@ -21,9 +21,9 @@ topic # out 1 mtconnect/ monitor/hemsaw/ok1/
 topic # in 1 control/ control/hemsaw/ok1/
 topic # out 1 monitor/ monitor/hemsaw/ok1/
 
-#The remote_clientid must be universally unique, 
+#The remote_clientid must be universally unique,
 #for all local mosquitto connected to the same edge broker
-remote_clientid broker1
+#remote_clientid broker1
 remote_username ssconnect-local-broker
 remote_password pwssconnect-local-broker
 

--- a/ssInstall.sh
+++ b/ssInstall.sh
@@ -63,10 +63,9 @@ InstallMTCAgent(){
         if test -d /etc/mqtt/config/; then
             echo "Updating MQTT bridge files"
 
-            # Generate a Broker UUID
+            # Load the Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
-            brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
-            sed -i "28 i\remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+            sed -i "28 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/
@@ -77,10 +76,9 @@ InstallMTCAgent(){
             mkdir -p /etc/mqtt/data/
             mkdir -p /etc/mqtt/certs/
 
-            # Generate a Broker UUID
+            # Load the Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
-            brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
-            sed -i "28 i\remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+            sed -i "28 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/

--- a/ssInstall.sh
+++ b/ssInstall.sh
@@ -62,7 +62,12 @@ InstallMTCAgent(){
     if $Use_MQTT_Bridge; then
         if test -d /etc/mqtt/config/; then
             echo "Updating MQTT bridge files"
+
+            # Generate a Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
+            brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
+            sed -i "26 i\#remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/
             chmod 0700 /etc/mqtt/data/acl
@@ -71,7 +76,12 @@ InstallMTCAgent(){
             mkdir -p /etc/mqtt/config/
             mkdir -p /etc/mqtt/data/
             mkdir -p /etc/mqtt/certs/
+
+            # Generate a Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
+            brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
+            sed -i "26 i\#remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/
             chmod 0700 /etc/mqtt/data/acl

--- a/ssInstall.sh
+++ b/ssInstall.sh
@@ -65,7 +65,7 @@ InstallMTCAgent(){
 
             # Load the Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
-            sed -i "28 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
+            sed -i "27 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/
@@ -78,7 +78,7 @@ InstallMTCAgent(){
 
             # Load the Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
-            sed -i "28 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
+            sed -i "27 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/

--- a/ssInstall.sh
+++ b/ssInstall.sh
@@ -66,7 +66,7 @@ InstallMTCAgent(){
             # Generate a Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
             brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
-            sed -i "26 i\#remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+            sed -i "28 i\remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/
@@ -80,7 +80,7 @@ InstallMTCAgent(){
             # Generate a Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
             brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
-            sed -i "26 i\#remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+            sed -i "28 i\remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/

--- a/ssUpgrade.sh
+++ b/ssUpgrade.sh
@@ -120,7 +120,7 @@ Update_MQTT_Broker(){
             # Generate a Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
             brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
-            sed -i "26 i\#remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+            sed -i "28 i\remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/
@@ -134,7 +134,7 @@ Update_MQTT_Broker(){
             # Generate a Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
             brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
-            sed -i "26 i\#remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+            sed -i "28 i\remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/

--- a/ssUpgrade.sh
+++ b/ssUpgrade.sh
@@ -117,10 +117,9 @@ Update_MQTT_Broker(){
         if test -d /etc/mqtt/config/; then
             echo "Updating MQTT bridge files"
 
-            # Generate a Broker UUID
+            # Load the Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
-            brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
-            sed -i "28 i\remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+            sed -i "28 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/
@@ -131,10 +130,9 @@ Update_MQTT_Broker(){
             mkdir -p /etc/mqtt/data/
             mkdir -p /etc/mqtt/certs/
 
-            # Generate a Broker UUID
+            # Load the Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
-            brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
-            sed -i "28 i\remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+            sed -i "28 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/

--- a/ssUpgrade.sh
+++ b/ssUpgrade.sh
@@ -114,9 +114,14 @@ Update_Agent(){
 
 Update_MQTT_Broker(){
     if $run_update_mqtt_bridge; then
-            if test -d /etc/mqtt/config/; then
+        if test -d /etc/mqtt/config/; then
             echo "Updating MQTT bridge files"
+
+            # Generate a Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
+            brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
+            sed -i "26 i\#remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/
             chmod 0700 /etc/mqtt/data/acl
@@ -125,7 +130,12 @@ Update_MQTT_Broker(){
             mkdir -p /etc/mqtt/config/
             mkdir -p /etc/mqtt/data/
             mkdir -p /etc/mqtt/certs/
+
+            # Generate a Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
+            brokerUUID=$(ip link show enp1s0 | awk '/link\/ether/{print $2}' | shasum | awk '{print $1}')
+            sed -i "26 i\#remote_clientid hemsaw_$brokerUUID" /etc/mqtt/config/mosquitto.conf
+
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/
             chmod 0700 /etc/mqtt/data/acl
@@ -146,7 +156,6 @@ Update_MQTT_Broker(){
         fi
     fi
     echo ""
-
 }
 
 Update_ODS(){

--- a/ssUpgrade.sh
+++ b/ssUpgrade.sh
@@ -119,7 +119,7 @@ Update_MQTT_Broker(){
 
             # Load the Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
-            sed -i "28 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
+            sed -i "27 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/
@@ -132,7 +132,7 @@ Update_MQTT_Broker(){
 
             # Load the Broker UUID
             cp -r ./mqtt/config/mosq_bridge.conf /etc/mqtt/config/mosquitto.conf
-            sed -i "28 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
+            sed -i "27 i\remote_clientid hemsaw-$Serial_Number" /etc/mqtt/config/mosquitto.conf
 
             cp -r ./mqtt/data/acl_bridge /etc/mqtt/data/acl
             cp -r ./mqtt/certs/. /etc/mqtt/certs/


### PR DESCRIPTION
The script creates a UUID using the mac address of the enp1s0 NIC and runs a shasum hash to obscure it. This is then sed into the broker config file as it is set in the /etc/mqtt/config/ folder. 